### PR TITLE
feat : [feat/#29/Jwt-0] Jwt 관련 로직 작성

### DIFF
--- a/a_uction/build.gradle
+++ b/a_uction/build.gradle
@@ -23,9 +23,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+
 
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	//jwt
+	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
+++ b/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
 	INVALID_REQUEST(BAD_REQUEST, "입력하신 데이터를 확인해 주세요. 잘못 된 요청입니다."),
 
 
+	INVALID_TOKEN(FORBIDDEN, "토큰이 만료되었습니다."),
 	EMAIL_FORMAT_ERROR(BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
 	THIS_EMAIL_ALREADY_EXIST(BAD_REQUEST, "해당 이메일은 이미 존재합니다.");
 	private final HttpStatus httpStatus;

--- a/a_uction/src/main/java/com/example/a_uction/security/config/SecurityConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/security/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.a_uction.security.config;
 
+import com.example.a_uction.security.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,12 +10,15 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 @Slf4j
 public class SecurityConfig {
 
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
@@ -23,9 +28,9 @@ public class SecurityConfig {
 			.and()
 				.authorizeRequests()
 					.antMatchers("/login/**", "/register/**").permitAll()
-     			.antMatchers("/**").permitAll()
+//     			.antMatchers("/**").permitAll()
 			.and()
-			//TODO jwt 필터 추가
+				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 			.build();
 	}
 	@Bean

--- a/a_uction/src/main/java/com/example/a_uction/security/jwt/JwtAuthenticationFilter.java
+++ b/a_uction/src/main/java/com/example/a_uction/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.example.a_uction.security.jwt;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private static final String TOKEN_HEADER = "Authorization";
+	private static final String TOKEN_PREFIX = "Bearer ";
+
+	private final JwtProvider provider;
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String token = resolveTokenFromRequest(request);
+
+		if (provider.validateToken(token)) {
+			UsernamePasswordAuthenticationToken authentication =
+				provider.getAuthentication(token);
+
+			authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+			SecurityContextHolder.getContext()
+				.setAuthentication(authentication);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+	private String resolveTokenFromRequest(HttpServletRequest request) {
+
+		String token = request.getHeader(TOKEN_HEADER);
+
+		if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+			return token.substring(TOKEN_PREFIX.length());
+		}
+
+		return null;
+	}
+}

--- a/a_uction/src/main/java/com/example/a_uction/security/jwt/JwtProvider.java
+++ b/a_uction/src/main/java/com/example/a_uction/security/jwt/JwtProvider.java
@@ -1,0 +1,65 @@
+package com.example.a_uction.security.jwt;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class JwtProvider {
+
+	private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;
+	private static final String CLAIM_KEY = "userEmail";
+	private static final String ROLE = "USER";
+	@Value("${spring.jwt.secret}")
+	private String secretKey;
+
+	public String createToken(String userEmail) {
+		Claims claims = Jwts.claims();
+		claims.put(CLAIM_KEY, userEmail);
+
+		long time = System.currentTimeMillis();
+
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(new Date(time))
+			.setExpiration(new Date(time + TOKEN_EXPIRE_TIME))
+			.signWith(SignatureAlgorithm.HS256, secretKey)
+			.compact();
+	}
+
+	public String getUserEmail(String token) {
+		return parseClaims(token).get(CLAIM_KEY, String.class);
+	}
+
+	public boolean validateToken(String token) {
+
+		if (!StringUtils.hasText(token)) {
+			return false;
+		}
+
+		return !parseClaims(token).getExpiration().before(new Date());
+	}
+
+	public UsernamePasswordAuthenticationToken getAuthentication(String token) {
+		return new UsernamePasswordAuthenticationToken(
+			getUserEmail(token), null, List.of(new SimpleGrantedAuthority(ROLE))
+		);
+	}
+
+	private Claims parseClaims(String token) {
+		try {
+			return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+		} catch (ExpiredJwtException e) {
+			return e.getClaims();
+		}
+	}
+}

--- a/a_uction/src/test/java/com/example/a_uction/controller/AuctionControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/AuctionControllerTest.java
@@ -4,6 +4,7 @@ import com.example.a_uction.model.auction.constants.AuctionStatus;
 import com.example.a_uction.model.auction.constants.ItemStatus;
 import com.example.a_uction.model.auction.dto.AuctionDto;
 import com.example.a_uction.model.auction.entity.AuctionEntity;
+import com.example.a_uction.security.jwt.JwtProvider;
 import com.example.a_uction.service.AuctionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,9 @@ class AuctionControllerTest {
 
     @MockBean
     private AuctionService auctionService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
 
     @Autowired
     private MockMvc mockMvc;

--- a/a_uction/src/test/java/com/example/a_uction/controller/UserRegisterControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/UserRegisterControllerTest.java
@@ -8,9 +8,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.exception.constants.ErrorCode;
 import com.example.a_uction.model.user.dto.RegisterUser;
+import com.example.a_uction.security.jwt.JwtProvider;
 import com.example.a_uction.service.UserRegisterService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -19,15 +23,18 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest
+@WebMvcTest(UserRegisterController.class)
 class UserRegisterControllerTest {
 
 	@MockBean
 	private UserRegisterService userRegisterService;
+	@MockBean
+	private JwtProvider jwtProvider;
 	@Autowired
 	private ObjectMapper objectMapper;
 	@Autowired
 	private MockMvc mockMvc;
+
 	@Test
 	@WithMockUser
 	void register_SUCCESS() throws Exception {
@@ -53,5 +60,29 @@ class UserRegisterControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.userEmail").value("zerobase@gmail.com"))
 			.andExpect(jsonPath("$.username").value("zerobase"));
+	}
+	@Test
+	@WithMockUser
+	@DisplayName("회원가입 실패 - 컨트롤러 테스트")
+	void register_FAIL() throws Exception {
+		//given
+		given(userRegisterService.register(any()))
+			.willThrow(new AuctionException(ErrorCode.THIS_EMAIL_ALREADY_EXIST));
+		//when
+		//then
+		mockMvc.perform(post("/register")
+				.with(csrf())
+				.content(objectMapper.writeValueAsString(
+					new RegisterUser.Request(
+						"zerobase@gmail.com",
+						"1234",
+						"zerobase",
+						"01012345678")
+				))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.errorCode").value("THIS_EMAIL_ALREADY_EXIST"))
+			.andExpect(jsonPath("$.message").value("해당 이메일은 이미 존재합니다."));
 	}
 }


### PR DESCRIPTION
Changes
---

security 와 jwt 를 같이 사용하기위해 securityFilterChain 에 JwtFilter 를 추가하였습니다.
provider 는 jwt관련 로직을 수행합니다.

Background
---

토큰에는 유저의 정보와 만료시간, secret-key을 암호화하여 저장합니다.
토큰에서 claim 을 파싱하여 해당 userEmail 을 가져올 수 있습니다.

closes #29 
