### PR TITLE
feat : [feat/#14/login-0] 서비스 자체 login 구현

### DIFF
--- a/a_uction/src/main/java/com/example/a_uction/AUctionApplication.java
+++ b/a_uction/src/main/java/com/example/a_uction/AUctionApplication.java
@@ -2,8 +2,10 @@ package com.example.a_uction;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AUctionApplication {
 
 	public static void main(String[] args) {

--- a/a_uction/src/main/java/com/example/a_uction/controller/UserLoginController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/UserLoginController.java
@@ -1,0 +1,35 @@
+package com.example.a_uction.controller;
+
+import com.example.a_uction.model.user.dto.LoginUser;
+import com.example.a_uction.service.UserLoginService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/login")
+public class UserLoginController {
+
+	private final UserLoginService userLoginService;
+
+	@PostMapping
+	public ResponseEntity<String> login(@Valid @RequestBody LoginUser user) {
+
+		return ResponseEntity.ok(userLoginService.login(user));
+	}
+
+	/**
+	 * test용 api
+	 */
+	@GetMapping
+	public ResponseEntity<String> test(Authentication authentication) {
+		return ResponseEntity.ok(authentication.getName());
+	}
+}

--- a/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
+++ b/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
 
 
 	INVALID_TOKEN(FORBIDDEN, "토큰이 만료되었습니다."),
+	NOT_FOUND_USER(BAD_REQUEST, "유저를 찾을 수 없습니다."),
+	ENTERED_THE_WRONG_PASSWORD(BAD_REQUEST, "비밀번호를 확인 해 주세요."),
 	EMAIL_FORMAT_ERROR(BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
 	THIS_EMAIL_ALREADY_EXIST(BAD_REQUEST, "해당 이메일은 이미 존재합니다."),
 

--- a/a_uction/src/main/java/com/example/a_uction/model/user/dto/LoginUser.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/dto/LoginUser.java
@@ -1,0 +1,17 @@
+package com.example.a_uction.model.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginUser {
+	private String userEmail;
+	private String password;
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/user/dto/RegisterUser.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/dto/RegisterUser.java
@@ -1,6 +1,7 @@
 package com.example.a_uction.model.user.dto;
 
 import com.example.a_uction.model.user.entity.UserEntity;
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,6 +30,7 @@ public class RegisterUser {
 	@NoArgsConstructor
 	@AllArgsConstructor
 	public static class Request {
+		@Email
 		@NotNull
 		private String userEmail;
 		@NotNull

--- a/a_uction/src/main/java/com/example/a_uction/model/user/entity/UserEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/entity/UserEntity.java
@@ -1,6 +1,8 @@
 package com.example.a_uction.model.user.entity;
 
+import java.time.LocalDateTime;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -11,6 +13,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Builder
@@ -18,6 +23,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class UserEntity {
 
 	@Id
@@ -30,4 +36,11 @@ public class UserEntity {
 	private String password;
 	private String username;
 	private String phoneNumber;
+	private boolean verify;
+
+	@CreatedDate
+	private LocalDateTime createDateTime;
+	@LastModifiedDate
+	private LocalDateTime updateDateTime;
+
 }

--- a/a_uction/src/main/java/com/example/a_uction/service/UserLoginService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/UserLoginService.java
@@ -1,0 +1,39 @@
+package com.example.a_uction.service;
+
+import static com.example.a_uction.exception.constants.ErrorCode.ENTERED_THE_WRONG_PASSWORD;
+import static com.example.a_uction.exception.constants.ErrorCode.NOT_FOUND_USER;
+
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.model.user.dto.LoginUser;
+import com.example.a_uction.model.user.entity.UserEntity;
+import com.example.a_uction.model.user.repository.UserRepository;
+import com.example.a_uction.security.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserLoginService {
+	private final UserRepository userRepository;
+	private final JwtProvider provider;
+	private final BCryptPasswordEncoder encoder;
+	public String login(LoginUser form) {
+
+		UserEntity user = userRepository.findByUserEmail(form.getUserEmail()).orElseThrow(
+			() -> new AuctionException(NOT_FOUND_USER)
+		);
+
+		if (!validationLogin(form.getPassword(), user.getPassword())) {
+			throw new AuctionException(ENTERED_THE_WRONG_PASSWORD);
+		}
+
+		return provider.createToken(user.getUserEmail());
+	}
+
+	private boolean validationLogin(String formPassword, String encodingPassword) {
+		return encoder.matches(formPassword, encodingPassword);
+	}
+}

--- a/a_uction/src/main/resources/application.yml
+++ b/a_uction/src/main/resources/application.yml
@@ -6,9 +6,10 @@ spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     username: root
-    password: 1234
+    password: 1
     url: jdbc:mariadb://localhost:3306/a_uction
-
+  jwt:
+    secret: "p2s5v8y/B?E(H+MbQeThWmZq3t6w9z$C"
   jpa:
     hibernate:
       ddl-auto: create

--- a/a_uction/src/test/java/com/example/a_uction/controller/AuctionControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/AuctionControllerTest.java
@@ -1,5 +1,16 @@
 package com.example.a_uction.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.example.a_uction.exception.AuctionException;
 import com.example.a_uction.exception.constants.ErrorCode;
 import com.example.a_uction.model.auction.constants.AuctionStatus;
@@ -9,25 +20,16 @@ import com.example.a_uction.model.auction.entity.AuctionEntity;
 import com.example.a_uction.security.jwt.JwtProvider;
 import com.example.a_uction.service.AuctionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.LocalDateTime;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AuctionController.class)
 class AuctionControllerTest {
@@ -37,6 +39,9 @@ class AuctionControllerTest {
 
     @MockBean
     private JwtProvider jwtProvider;
+
+    @MockBean
+    private JpaMetamodelMappingContext context;
 
     @Autowired
     private MockMvc mockMvc;
@@ -113,7 +118,7 @@ class AuctionControllerTest {
         //when
         //then
         mockMvc.perform(put("/auction").with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .contentType(MediaType.APPLICATION_JSON)
                         .param("auctionId", "1")
                         .content(objectMapper.writeValueAsString(updateAuction)))
                 .andExpect(jsonPath("$.itemName").value("item2"))
@@ -145,10 +150,10 @@ class AuctionControllerTest {
         //when
         //then
         mockMvc.perform(put("/auction").with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .contentType(MediaType.APPLICATION_JSON)
                         .param("auctionId", "1")
                         .content(objectMapper.writeValueAsString(updateAuction)))
-                .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.errorCode").value("INTERNAL_SERVER_ERROR"))
                 .andExpect(status().isOk());
     }
 
@@ -174,7 +179,7 @@ class AuctionControllerTest {
         //when
         //then
         mockMvc.perform(put("/auction").with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .contentType(MediaType.APPLICATION_JSON)
                         .param("auctionId", "1")
                         .content(objectMapper.writeValueAsString(updateAuction)))
                 .andExpect(jsonPath("$.errorCode").value("BEFORE_START_TIME"))
@@ -190,53 +195,23 @@ class AuctionControllerTest {
         LocalDateTime endTime = LocalDateTime.now().minusDays(10);
 
         AuctionDto.Request updateAuction = AuctionDto.Request.builder()
-                .itemName("item2")
-                .startDateTime(startTime)
-                .endDateTime(endTime)
-                .itemStatus(ItemStatus.GOOD)
-                .minimumBid(2000)
-                .startingPrice(1000)
-                .build();
+            .itemName("item2")
+            .startDateTime(startTime)
+            .endDateTime(endTime)
+            .itemStatus(ItemStatus.GOOD)
+            .minimumBid(2000)
+            .startingPrice(1000)
+            .build();
 
         given(auctionService.updateAuction(any(AuctionDto.Request.class), anyInt(), anyLong()))
-                .willThrow(new AuctionException(ErrorCode.END_TIME_EARLIER_THAN_START_TIME));
+            .willThrow(new AuctionException(ErrorCode.END_TIME_EARLIER_THAN_START_TIME));
         //when
         //then
         mockMvc.perform(put("/auction").with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON_UTF8)
-                        .param("auctionId", "1")
-                        .content(objectMapper.writeValueAsString(updateAuction)))
-                .andExpect(jsonPath("$.errorCode").value("END_TIME_EARLIER_THAN_START_TIME"))
-                .andExpect(status().isOk());
-
-    @Test
-    @DisplayName("경매 읽기 성공")
-    @WithMockUser
-    void getAuctionByAuctionId_SUCCESS() throws Exception {
-        AuctionDto.Response auctionDto = AuctionDto.Response.builder()
-                .itemName("test item2")
-                .itemStatus(ItemStatus.GOOD)
-                .startingPrice(2000)
-                .minimumBid(200)
-                .auctionStatus(AuctionStatus.SCHEDULED)
-                .startDateTime(LocalDateTime.parse("2023-04-15T17:09:42.411"))
-                .endDateTime(LocalDateTime.parse("2023-04-15T17:10:42.411"))
-                .build();
-        given(auctionService.getAuctionByAuctionId(anyLong()))
-                .willReturn(auctionDto);
-        mockMvc.perform(get("/auction/" + 1L)
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.auctionStatus").value(AuctionStatus.SCHEDULED.name()))
-                .andExpect(jsonPath("$.itemName").value("test item2"))
-                .andExpect(jsonPath("$.itemStatus").value(ItemStatus.GOOD.name()))
-                .andExpect(jsonPath("$.startingPrice").value(2000))
-                .andExpect(jsonPath("$.minimumBid").value(200))
-                .andExpect(jsonPath("$.auctionStatus").value(AuctionStatus.SCHEDULED.name()))
-                .andExpect(jsonPath("$.startDateTime").value("2023-04-15T17:09:42.411"))
-                .andExpect(jsonPath("$.endDateTime").value("2023-04-15T17:10:42.411"));
-
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("auctionId", "1")
+                .content(objectMapper.writeValueAsString(updateAuction)))
+            .andExpect(jsonPath("$.errorCode").value("END_TIME_EARLIER_THAN_START_TIME"))
+            .andExpect(status().isOk());
     }
 }

--- a/a_uction/src/test/java/com/example/a_uction/controller/UserRegisterControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/UserRegisterControllerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,6 +31,9 @@ class UserRegisterControllerTest {
 	private UserRegisterService userRegisterService;
 	@MockBean
 	private JwtProvider jwtProvider;
+	@MockBean
+	private JpaMetamodelMappingContext context;
+
 	@Autowired
 	private ObjectMapper objectMapper;
 	@Autowired

--- a/auction-user-api.http
+++ b/auction-user-api.http
@@ -8,3 +8,35 @@ Content-Type: application/json
   "username": "zerobase",
   "phoneNumber": "01012345678"
 }
+
+###로그인 성공
+POST http://localhost:8081/login
+Content-Type: application/json
+
+{
+  "userEmail": "zerobase@gmail.com",
+  "password": "1234"
+}
+
+###로그인 실패 - 이메일 틀림
+POST http://localhost:8081/login
+Content-Type: application/json
+
+{
+  "userEmail": "zerobase@g.c",
+  "password": "1234"
+}
+
+###로그인 실패 - 비밀번호 틀림
+POST http://localhost:8081/login
+Content-Type: application/json
+
+{
+  "userEmail": "zerobase@gmail.com",
+  "password": "123"
+}
+
+###토큰으로 유저 이메일 받아오기
+GET http://localhost:8081/login
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZUBnbWFpbC5jb20iLCJpYXQiOjE2ODA4NTY1ODcsImV4cCI6MTY4MDk0Mjk4N30.NaNESfUwfZhEfJpXMIkvUGC8IHS_q_rU_srVp7V8eGU


### PR DESCRIPTION
Changes
---

로그인 시 userEmail 로 토큰을 생성하고 반환
간단한 http 테스트 코드를 작성하였습니다.
유효성검사는 email 확인 검사와 password 확인 검사를 진행하였습니다.

Background
---
모든 요청 헤더에 Authorization 에 Bearer {jwt} 붙여서 요청하면 userEmail 을 가져올 수 있습니다.