### PR TITLE
[feat/#37/readAuction/2] #36 테스트 코드 / 토큰을 통해 사용자 정보 가져와 반영

### DIFF
--- a/a_uction/src/main/java/com/example/a_uction/controller/AuctionController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/AuctionController.java
@@ -7,26 +7,31 @@ import com.example.a_uction.model.auction.constants.AuctionStatus;
 import com.example.a_uction.model.auction.dto.AuctionDto;
 import com.example.a_uction.service.AuctionService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/auction")
 @RequiredArgsConstructor
+@Slf4j
 public class AuctionController {
 
     private final AuctionService auctionService;
 
     @PostMapping
-    public ResponseEntity<AuctionDto.Response> addAuction(@RequestBody @Valid AuctionDto.Request auction, BindingResult bindingResult) {
+    public ResponseEntity<AuctionDto.Response> addAuction(@RequestBody @Valid AuctionDto.Request auction,
+                                                          BindingResult bindingResult,
+                                                          Principal principal) {
         if (bindingResult.hasErrors()){
             throw new AuctionException(ErrorCode.INVALID_REQUEST);
         }
-        return ResponseEntity.ok(auctionService.addAuction(auction));
+        return ResponseEntity.ok(auctionService.addAuction(auction, principal.getName()));
     }
 
     @GetMapping("/{auctionId}")
@@ -36,28 +41,22 @@ public class AuctionController {
 
     @PutMapping
     public ResponseEntity<?> updateAction(@RequestBody AuctionDto.Request updateAuction,
-                                          @RequestParam Long auctionId){
-        //TODO userId 토큰을 통해 받을 예정
-        int userId = 0;
-        return ResponseEntity.ok(auctionService.updateAuction(updateAuction, userId, auctionId));
+                                          @RequestParam Long auctionId,Principal principal){
+        return ResponseEntity.ok(auctionService.updateAuction(updateAuction, principal.getName(), auctionId));
     }
 
 
     @GetMapping("/read")
-    public ResponseEntity<?> getAllAuctionListByUserId(Pageable pageable){
-        //TODO userId 토큰을 통해 받을 예정
-        int userId = 0;
-        return ResponseEntity.ok(auctionService.getAllAuctionListByUserId(userId, pageable));
+    public ResponseEntity<?> getAllAuctionListByUserId(Principal principal, Pageable pageable){
+        return ResponseEntity.ok(auctionService.getAllAuctionListByUserId(principal.getName(), pageable));
     }
 
     @GetMapping("/read/{auctionStatus}")
-    public ResponseEntity<?> getAuctionListByUserIdAndStatus(@PathVariable AuctionStatus auctionStatus,
+    public ResponseEntity<?> getAuctionListByUserIdAndStatus(Principal principal, @PathVariable AuctionStatus auctionStatus,
             Pageable pageable){
 
-        //TODO userId 토큰을 통해 받을 예정
-        int userId = 0;
-        var result = auctionService.getAuctionListByUserIdAndAuctionStatus(userId, auctionStatus, pageable);
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(auctionService.getAuctionListByUserIdAndAuctionStatus(
+                principal.getName(), auctionStatus, pageable));
     }
 
 

--- a/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
+++ b/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
 	//auction
 	BEFORE_START_TIME (BAD_REQUEST, "경매 시작 시간이 등록 시간보다 이전입니다."),
 	END_TIME_EARLIER_THAN_START_TIME (BAD_REQUEST, "경매 종료 시간이 경매 시작 시간보다 이전입니다."),
-	NOT_FOUND_AUCTION_LIST(BAD_REQUEST, "등록하신 경매 이력이 없습니다.")
+	NOT_FOUND_AUCTION_LIST(BAD_REQUEST, "등록하신 경매 이력이 없습니다."),
+	UNABLE_UPDATE_AUCTION(BAD_REQUEST, "진행 예정인 경매만 수정이 가능합니다.")
 	;
 	private final HttpStatus httpStatus;
 	private final String description;

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/dto/AuctionDto.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/dto/AuctionDto.java
@@ -27,8 +27,9 @@ public class AuctionDto {
         private LocalDateTime startDateTime;
         private LocalDateTime endDateTime;
 
-        public AuctionEntity toEntity(){
+        public AuctionEntity toEntity(String userId){
             return AuctionEntity.builder()
+                    .userId(userId)
                     .itemName(this.itemName)
                     .itemStatus(this.itemStatus)
                     .startingPrice(this.startingPrice)

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionEntity.java
@@ -22,7 +22,7 @@ public class AuctionEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long auctionId;
     //@ManyToOne(targetEntity = .class, fetch = FetchType.LAZY)
-    private int userId;
+    private String userId;
 
     @NotNull(message = "상품 이름을 입력하세요")
     private String itemName;

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/repository/AuctionRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/repository/AuctionRepository.java
@@ -11,10 +11,10 @@ import java.util.Optional;
 
 @Repository
 public interface AuctionRepository extends JpaRepository<AuctionEntity, Long> {
-    Optional<AuctionEntity> findByUserIdAndAuctionId(int userId, Long auctionId);
+    Optional<AuctionEntity> findByUserIdAndAuctionId(String userId, Long auctionId);
 
-    Page<AuctionEntity> findByUserId(int userId, Pageable pageable);
+    Page<AuctionEntity> findByUserId(String userId, Pageable pageable);
 
-    Page<AuctionEntity> findByUserIdAndAuctionStatus(int userId, AuctionStatus auctionStatus, Pageable pageable);
+    Page<AuctionEntity> findByUserIdAndAuctionStatus(String userId, AuctionStatus auctionStatus, Pageable pageable);
 
 }


### PR DESCRIPTION
Change
---

1. #36 에 대한 test 코드 구현
2. jwt 토큰을 통해 사용자 이메일 받아와 경매에서 사용자 부분 반영
    1. 기존 경매 등록시 사용자 이름 임의로 숫자로 등록 -> 사용자 이메일로 변경
    2. 사용자의 경매 리스트를 가져 올때 경매 등록시에 사용하였던 숫자 사용 -> 사용자 이메일로 변경

Background
---
auction 테이블과 user 테이블 연관성 추가 필요

closes #37