### PR TITLE
feat: [Feat/#40/kakaoLogout] 카카오 로그아웃 구현 및 refreshToken 추가

### DIFF
--- a/a_uction/build.gradle
+++ b/a_uction/build.gradle
@@ -25,12 +25,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 
-
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	//jwt
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/a_uction/src/main/java/com/example/a_uction/config/RedisConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.example.a_uction.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		StringRedisSerializer serializer = new StringRedisSerializer();
+
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+		redisTemplate.setKeySerializer(serializer);
+		redisTemplate.setValueSerializer(serializer);
+		redisTemplate.setHashKeySerializer(serializer);
+		redisTemplate.setHashValueSerializer(serializer);
+		return redisTemplate;
+	}
+}

--- a/a_uction/src/main/java/com/example/a_uction/config/RestTemplateConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/config/RestTemplateConfig.java
@@ -1,13 +1,7 @@
 package com.example.a_uction.config;
 
-import java.nio.charset.Charset;
-import java.time.Duration;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.BufferingClientHttpRequestFactory;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration

--- a/a_uction/src/main/java/com/example/a_uction/controller/UserLoginController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/UserLoginController.java
@@ -1,6 +1,7 @@
 package com.example.a_uction.controller;
 
 import com.example.a_uction.model.user.dto.LoginUser;
+import com.example.a_uction.security.jwt.dto.TokenDto;
 import com.example.a_uction.service.UserLoginService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ public class UserLoginController {
 	private final UserLoginService userLoginService;
 
 	@PostMapping("/login")
-	public ResponseEntity<String> login(@Valid @RequestBody LoginUser user) {
+	public ResponseEntity<TokenDto> login(@Valid @RequestBody LoginUser user) {
 
 		return ResponseEntity.ok(userLoginService.login(user));
 	}

--- a/a_uction/src/main/java/com/example/a_uction/controller/user/KakaoController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/user/KakaoController.java
@@ -1,9 +1,12 @@
 package com.example.a_uction.controller.user;
 
 import com.example.a_uction.service.user.KakaoService;
+import java.security.Principal;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,5 +26,21 @@ public class KakaoController {
 		log.info("[CODE = {}]", code);
 		return ResponseEntity.ok(kakaoService.kakaoLogIn(code));
 
+	}
+
+	@GetMapping("/kakao/logout")
+	public ResponseEntity<?> kakaoLogout(HttpServletRequest request) {
+		return ResponseEntity.ok(kakaoService.kakaoLogout(request));
+
+	}
+
+	/**
+	 * test용 api
+	 */
+	@GetMapping("/detail")
+	public ResponseEntity<String> test(Authentication authentication, Principal principal) {
+		authentication.setAuthenticated(false);
+		log.info(principal.getName());
+		return ResponseEntity.ok(authentication.getName());
 	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
+++ b/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
 	ENTERED_THE_WRONG_PASSWORD(BAD_REQUEST, "비밀번호를 확인 해 주세요."),
 	EMAIL_FORMAT_ERROR(BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
 	THIS_EMAIL_ALREADY_EXIST(BAD_REQUEST, "해당 이메일은 이미 존재합니다."),
+	LOGOUT_USER_ERROR(BAD_REQUEST, "로그아웃 된 사용자입니다."),
 
 	// kakao
 	INVALID_PARSE_ERROR(BAD_REQUEST, "JSON 파싱에 실패하였습니다."),

--- a/a_uction/src/main/java/com/example/a_uction/model/user/dto/LogoutUser.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/dto/LogoutUser.java
@@ -1,0 +1,18 @@
+package com.example.a_uction.model.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LogoutUser {
+	private String userEmail;
+
+	// 아직 request, response 데이터 확정하지 못함
+}

--- a/a_uction/src/main/java/com/example/a_uction/security/jwt/dto/TokenDto.java
+++ b/a_uction/src/main/java/com/example/a_uction/security/jwt/dto/TokenDto.java
@@ -1,0 +1,17 @@
+package com.example.a_uction.security.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenDto {
+	String accessToken;
+	String refreshToken;
+
+	long refreshTokenExpireTime;
+}

--- a/a_uction/src/test/java/com/example/a_uction/controller/AuctionControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/AuctionControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -46,6 +47,8 @@ class AuctionControllerTest {
     private JwtProvider jwtProvider;
     @MockBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+    @MockBean
+    private RedisTemplate redisTemplate;
 
     @Autowired
     private MockMvc mockMvc;

--- a/a_uction/src/test/java/com/example/a_uction/controller/UserLoginControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/UserLoginControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.example.a_uction.exception.AuctionException;
 import com.example.a_uction.exception.constants.ErrorCode;
 import com.example.a_uction.model.user.dto.LoginUser;
+import com.example.a_uction.security.jwt.dto.TokenDto;
 import com.example.a_uction.service.UserLoginService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -41,7 +42,10 @@ class UserLoginControllerTest {
 	@DisplayName("로그인 성공")
 	void login_SUCCESS() throws Exception {
 		given(userLoginService.login(any()))
-			.willReturn("tokentoken");
+			.willReturn(TokenDto.builder()
+				.accessToken("tokentoken")
+				.refreshToken("refreshToken")
+				.build());
 
 		mockMvc.perform(post("/login")
 				.with(csrf())


### PR DESCRIPTION
Changes
---

- 카카오 로그아웃 구현
- 기존 로그인에서 String token 리턴에서 accessToken, refreshToken 을 담은 tokenDto리턴
- refresh토큰을 생성 시 redis에 저장 

ToReviewrs
---

- 기존 작성된 테스트들은 정상 통과 확인 
- pull 이후 yml에서 redis 환경 설정 , oauth 설정 추가 