### PR TITLE
Feat/#46/modify user detail/0  회원정보 수정

### DIFF
--- a/a_uction/src/main/java/com/example/a_uction/controller/AuctionController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/AuctionController.java
@@ -8,6 +8,7 @@ import com.example.a_uction.model.auction.dto.AuctionDto;
 import com.example.a_uction.service.AuctionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -40,20 +41,20 @@ public class AuctionController {
     }
 
     @PutMapping
-    public ResponseEntity<?> updateAction(@RequestBody AuctionDto.Request updateAuction,
+    public ResponseEntity<AuctionDto.Response> updateAction(@RequestBody AuctionDto.Request updateAuction,
                                           @RequestParam Long auctionId,Principal principal){
         return ResponseEntity.ok(auctionService.updateAuction(updateAuction, principal.getName(), auctionId));
     }
 
 
     @GetMapping("/read")
-    public ResponseEntity<?> getAllAuctionListByUserId(Principal principal, Pageable pageable){
+    public ResponseEntity<Page<AuctionDto.Response>> getAllAuctionListByUserId(Principal principal, Pageable pageable){
         return ResponseEntity.ok(auctionService.getAllAuctionListByUserEmail(principal.getName(), pageable));
     }
 
     @GetMapping("/read/{auctionStatus}")
-    public ResponseEntity<?> getAuctionListByUserIdAndStatus(Principal principal, @PathVariable AuctionStatus auctionStatus,
-            Pageable pageable){
+    public ResponseEntity<Page<AuctionDto.Response>> getAuctionListByUserIdAndStatus(
+            Principal principal, @PathVariable AuctionStatus auctionStatus, Pageable pageable){
 
         return ResponseEntity.ok(auctionService.getAuctionListByUserEmailAndAuctionStatus(
                 principal.getName(), auctionStatus, pageable));

--- a/a_uction/src/main/java/com/example/a_uction/controller/AuctionController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/AuctionController.java
@@ -48,14 +48,14 @@ public class AuctionController {
 
     @GetMapping("/read")
     public ResponseEntity<?> getAllAuctionListByUserId(Principal principal, Pageable pageable){
-        return ResponseEntity.ok(auctionService.getAllAuctionListByUserId(principal.getName(), pageable));
+        return ResponseEntity.ok(auctionService.getAllAuctionListByUserEmail(principal.getName(), pageable));
     }
 
     @GetMapping("/read/{auctionStatus}")
     public ResponseEntity<?> getAuctionListByUserIdAndStatus(Principal principal, @PathVariable AuctionStatus auctionStatus,
             Pageable pageable){
 
-        return ResponseEntity.ok(auctionService.getAuctionListByUserIdAndAuctionStatus(
+        return ResponseEntity.ok(auctionService.getAuctionListByUserEmailAndAuctionStatus(
                 principal.getName(), auctionStatus, pageable));
     }
 

--- a/a_uction/src/main/java/com/example/a_uction/controller/UserInfoModifyController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/UserInfoModifyController.java
@@ -18,8 +18,8 @@ public class UserInfoModifyController {
 	private final UserModifyService userModifyService;
 
 	@PostMapping("/detail/modify")
-	public ResponseEntity<?> modify(Principal principal,
-									@RequestBody ModifyUser.Request request) {
+	public ResponseEntity<ModifyUser.Response> modify(Principal principal,
+													  @RequestBody ModifyUser.Request request) {
 
 		return ResponseEntity.ok(userModifyService.modifyUserDetail(principal.getName(), request));
 	}

--- a/a_uction/src/main/java/com/example/a_uction/controller/UserInfoModifyController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/UserInfoModifyController.java
@@ -1,0 +1,26 @@
+package com.example.a_uction.controller;
+
+import com.example.a_uction.model.user.dto.ModifyUser;
+import com.example.a_uction.service.UserModifyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserInfoModifyController {
+	private final UserModifyService userModifyService;
+
+	@PostMapping("/detail/modify")
+	public ResponseEntity<?> modify(Principal principal,
+									@RequestBody ModifyUser.Request request) {
+
+		return ResponseEntity.ok(userModifyService.modifyUserDetail(principal.getName(), request));
+	}
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/dto/AuctionDto.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/dto/AuctionDto.java
@@ -27,9 +27,9 @@ public class AuctionDto {
         private LocalDateTime startDateTime;
         private LocalDateTime endDateTime;
 
-        public AuctionEntity toEntity(String userId){
+        public AuctionEntity toEntity(String userEmail){
             return AuctionEntity.builder()
-                    .userId(userId)
+                    .userEmail(userEmail)
                     .itemName(this.itemName)
                     .itemStatus(this.itemStatus)
                     .startingPrice(this.startingPrice)

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionEntity.java
@@ -22,7 +22,7 @@ public class AuctionEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long auctionId;
     //@ManyToOne(targetEntity = .class, fetch = FetchType.LAZY)
-    private String userId;
+    private String userEmail;
 
     @NotNull(message = "상품 이름을 입력하세요")
     private String itemName;

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/repository/AuctionRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/repository/AuctionRepository.java
@@ -11,9 +11,9 @@ import java.util.Optional;
 
 @Repository
 public interface AuctionRepository extends JpaRepository<AuctionEntity, Long> {
-    Optional<AuctionEntity> findByUserIdAndAuctionId(String userId, Long auctionId);
+    Optional<AuctionEntity> findByUserEmailAndAuctionId(String userEmail, Long auctionId);
 
-    Page<AuctionEntity> findByUserId(String userId, Pageable pageable);
+    Page<AuctionEntity> findByUserEmail(String userEmail, Pageable pageable);
 
     Page<AuctionEntity> findByUserIdAndAuctionStatus(String userId, AuctionStatus auctionStatus, Pageable pageable);
 

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/repository/AuctionRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/repository/AuctionRepository.java
@@ -15,6 +15,6 @@ public interface AuctionRepository extends JpaRepository<AuctionEntity, Long> {
 
     Page<AuctionEntity> findByUserEmail(String userEmail, Pageable pageable);
 
-    Page<AuctionEntity> findByUserIdAndAuctionStatus(String userId, AuctionStatus auctionStatus, Pageable pageable);
+    Page<AuctionEntity> findByUserEmailAndAuctionStatus(String userEmail, AuctionStatus auctionStatus, Pageable pageable);
 
 }

--- a/a_uction/src/main/java/com/example/a_uction/model/user/dto/ModifyUser.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/dto/ModifyUser.java
@@ -1,0 +1,38 @@
+package com.example.a_uction.model.user.dto;
+
+import com.example.a_uction.model.user.entity.UserEntity;
+import lombok.*;
+
+public class ModifyUser {
+
+	@Getter
+	@Setter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Request{
+		private String currentPassword;
+		private String updatePassword;
+		private String username;
+		private String phone;
+	}
+
+	@Getter
+	@Setter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Response{
+		private String username;
+		private String phone;
+
+		public ModifyUser.Response fromEntity(UserEntity userEntity){
+			return Response.builder()
+					.phone(userEntity.getPhoneNumber())
+					.username(userEntity.getUsername())
+					.build();
+		}
+
+	}
+
+}

--- a/a_uction/src/main/java/com/example/a_uction/service/AuctionService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/AuctionService.java
@@ -80,7 +80,7 @@ public class AuctionService {
     public Page<AuctionDto.Response> getAuctionListByUserEmailAndAuctionStatus(
             String userEmail, AuctionStatus auctionStatus, Pageable pageable) {
 
-        Page<AuctionEntity> auctionList = auctionRepository.findByUserIdAndAuctionStatus(userEmail, auctionStatus, pageable);
+        Page<AuctionEntity> auctionList = auctionRepository.findByUserEmailAndAuctionStatus(userEmail, auctionStatus, pageable);
         if(auctionList.isEmpty()) throw new AuctionException(AUCTION_NOT_FOUND);
 
         return auctionList.map(m -> new AuctionDto.Response().fromEntity(m));

--- a/a_uction/src/main/java/com/example/a_uction/service/AuctionService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/AuctionService.java
@@ -20,7 +20,7 @@ import static com.example.a_uction.exception.constants.ErrorCode.*;
 public class AuctionService {
     private final AuctionRepository auctionRepository;
 
-    public AuctionDto.Response addAuction(AuctionDto.Request auction, String userId){
+    public AuctionDto.Response addAuction(AuctionDto.Request auction, String userEmail){
         if (auction.getEndDateTime().isBefore(auction.getStartDateTime())){
             // 경매 종료 시간이 경매 시작 시간보다 이트름
             throw new AuctionException(END_TIME_EARLIER_THAN_START_TIME);
@@ -31,7 +31,7 @@ public class AuctionService {
             throw new AuctionException(BEFORE_START_TIME);
         }
         auction.setAuctionStatus(AuctionStatus.SCHEDULED);
-        return new AuctionDto.Response().fromEntity(auctionRepository.save(auction.toEntity(userId)));
+        return new AuctionDto.Response().fromEntity(auctionRepository.save(auction.toEntity(userEmail)));
     }
 
     public AuctionDto.Response getAuctionByAuctionId(Long auctionId){
@@ -40,8 +40,8 @@ public class AuctionService {
         return new AuctionDto.Response().fromEntity(auctionEntity);
     }
 
-    public AuctionDto.Response updateAuction(AuctionDto.Request updateAuction, String userId, Long auctionId){
-        var auction =  auctionRepository.findByUserIdAndAuctionId(userId, auctionId)
+    public AuctionDto.Response updateAuction(AuctionDto.Request updateAuction, String userEmail, Long auctionId){
+        var auction =  auctionRepository.findByUserEmailAndAuctionId(userEmail, auctionId)
                 .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
 
         if(!auction.getAuctionStatus().equals(AuctionStatus.SCHEDULED)){
@@ -70,17 +70,17 @@ public class AuctionService {
         return new AuctionDto.Response().fromEntity(auctionRepository.save(auction));
     }
 
-    public Page<AuctionDto.Response> getAllAuctionListByUserId(String userEmail, Pageable pageable){
-        var auctionList =  auctionRepository.findByUserId(userEmail, pageable);
+    public Page<AuctionDto.Response> getAllAuctionListByUserEmail(String userEmail, Pageable pageable){
+        var auctionList =  auctionRepository.findByUserEmail(userEmail, pageable);
         if(auctionList.isEmpty()) throw new AuctionException(NOT_FOUND_AUCTION_LIST);
 
         return auctionList.map(m -> new AuctionDto.Response().fromEntity(m));
     }
 
-    public Page<AuctionDto.Response> getAuctionListByUserIdAndAuctionStatus(
-            String userId, AuctionStatus auctionStatus, Pageable pageable) {
+    public Page<AuctionDto.Response> getAuctionListByUserEmailAndAuctionStatus(
+            String userEmail, AuctionStatus auctionStatus, Pageable pageable) {
 
-        Page<AuctionEntity> auctionList = auctionRepository.findByUserIdAndAuctionStatus(userId, auctionStatus, pageable);
+        Page<AuctionEntity> auctionList = auctionRepository.findByUserIdAndAuctionStatus(userEmail, auctionStatus, pageable);
         if(auctionList.isEmpty()) throw new AuctionException(AUCTION_NOT_FOUND);
 
         return auctionList.map(m -> new AuctionDto.Response().fromEntity(m));

--- a/a_uction/src/main/java/com/example/a_uction/service/UserModifyService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/UserModifyService.java
@@ -1,0 +1,43 @@
+package com.example.a_uction.service;
+
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.model.user.dto.ModifyUser;
+import com.example.a_uction.model.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+import static com.example.a_uction.exception.constants.ErrorCode.ENTERED_THE_WRONG_PASSWORD;
+import static com.example.a_uction.exception.constants.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserModifyService {
+
+	private final UserRepository userRepository;
+	private final BCryptPasswordEncoder passwordEncoder;
+
+	public ModifyUser.Response modifyUserDetail(String userEmail, ModifyUser.Request updateRequest) {
+		var userEntity = userRepository.findByUserEmail(userEmail)
+				.orElseThrow(() -> new AuctionException(USER_NOT_FOUND));
+
+		//현재 비밀번호 일치 여부확인
+		if(!passwordEncoder.matches(updateRequest.getCurrentPassword(), userEntity.getPassword())){
+			throw new AuctionException(ENTERED_THE_WRONG_PASSWORD);
+		}
+
+		userEntity.setUsername(updateRequest.getUsername());
+		userEntity.setPhoneNumber(updateRequest.getPhone());
+		userEntity.setUpdateDateTime(LocalDateTime.now());
+
+		if(!updateRequest.getUpdatePassword().isEmpty()){
+			userEntity.setPassword(passwordEncoder.encode(updateRequest.getUpdatePassword()));
+		}
+
+		return new ModifyUser.Response().fromEntity(userRepository.save(userEntity));
+	}
+}

--- a/a_uction/src/main/java/com/example/a_uction/service/UserModifyService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/UserModifyService.java
@@ -32,7 +32,6 @@ public class UserModifyService {
 
 		userEntity.setUsername(updateRequest.getUsername());
 		userEntity.setPhoneNumber(updateRequest.getPhone());
-		userEntity.setUpdateDateTime(LocalDateTime.now());
 
 		if(!updateRequest.getUpdatePassword().isEmpty()){
 			userEntity.setPassword(passwordEncoder.encode(updateRequest.getUpdatePassword()));

--- a/a_uction/src/test/java/com/example/a_uction/controller/AuctionControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/AuctionControllerTest.java
@@ -110,7 +110,7 @@ class AuctionControllerTest {
 
         AuctionEntity auctionEntity = AuctionEntity.builder()
                 .auctionId(1L)
-                .userId("user1")
+                .userEmail("user1")
                 .itemName("item2")
                 .startingPrice(1000)
                 .minimumBid(2000)
@@ -279,7 +279,7 @@ class AuctionControllerTest {
 
         Page<AuctionDto.Response> page = new PageImpl<>(list);
 
-        given(auctionService.getAllAuctionListByUserId(any(), any())).willReturn(page);
+        given(auctionService.getAllAuctionListByUserEmail(any(), any())).willReturn(page);
 
         //when
         //then
@@ -304,7 +304,7 @@ class AuctionControllerTest {
     @WithMockUser
     void getAllAuctionListByUserIdFail() throws Exception {
         //given
-        given(auctionService.getAllAuctionListByUserId(any(),any()))
+        given(auctionService.getAllAuctionListByUserEmail(any(),any()))
                 .willThrow(new AuctionException(NOT_FOUND_AUCTION_LIST));
         //when
         //then
@@ -342,7 +342,7 @@ class AuctionControllerTest {
 
         Page<AuctionDto.Response> page = new PageImpl<>(list);
 
-        given(auctionService.getAuctionListByUserIdAndAuctionStatus(any(), any(), any())).willReturn(page);
+        given(auctionService.getAuctionListByUserEmailAndAuctionStatus(any(), any(), any())).willReturn(page);
 
         //when
         //then
@@ -367,7 +367,7 @@ class AuctionControllerTest {
     @WithMockUser
     void getAuctionListByUserIdAndStatusFail() throws Exception {
         //given
-        given(auctionService.getAuctionListByUserIdAndAuctionStatus(any(),any(),any()))
+        given(auctionService.getAuctionListByUserEmailAndAuctionStatus(any(),any(),any()))
                 .willThrow(new AuctionException(AUCTION_NOT_FOUND));
         //when
         //then

--- a/a_uction/src/test/java/com/example/a_uction/service/AuctionServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/AuctionServiceTest.java
@@ -381,7 +381,7 @@ class AuctionServiceTest {
         );
         Page<AuctionEntity> page = new PageImpl<>(list);
 
-        given(auctionRepository.findByUserIdAndAuctionStatus(any(), any(), any())).willReturn(page);
+        given(auctionRepository.findByUserEmailAndAuctionStatus(any(), any(), any())).willReturn(page);
 
         //when
         var result = auctionService.getAuctionListByUserEmailAndAuctionStatus("user1", AuctionStatus.SCHEDULED, Pageable.ofSize(10));
@@ -404,7 +404,7 @@ class AuctionServiceTest {
     @DisplayName("경매 상태 별 리스트 가져오기 - 실패")
     void getAuctionListByUserIdAndAuctionStatusFail(){
         //given
-        given(auctionRepository.findByUserIdAndAuctionStatus(any(), any(), any())).willReturn(Page.empty());
+        given(auctionRepository.findByUserEmailAndAuctionStatus(any(), any(), any())).willReturn(Page.empty());
 
         //when
         AuctionException exception = assertThrows(AuctionException.class,

--- a/a_uction/src/test/java/com/example/a_uction/service/AuctionServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/AuctionServiceTest.java
@@ -177,9 +177,8 @@ class AuctionServiceTest {
                 .build();
 
         AuctionEntity auctionEntity = AuctionEntity.builder()
-                .userId("user1")
+                .userEmail("user1")
                 .auctionId(1L)
-                .userId("user1")
                 .itemName("item")
                 .startingPrice(1234)
                 .minimumBid(1000)
@@ -190,7 +189,7 @@ class AuctionServiceTest {
                 .endDateTime(LocalDateTime.of(2023,4,10,00,00,00))
                 .build();
 
-        given(auctionRepository.findByUserIdAndAuctionId(any(), anyLong()))
+        given(auctionRepository.findByUserEmailAndAuctionId(any(), anyLong()))
                 .willReturn(Optional.ofNullable(auctionEntity));
         given(auctionRepository.save(any())).willReturn(auctionEntity);
 
@@ -224,7 +223,7 @@ class AuctionServiceTest {
 
         AuctionEntity auctionEntity = AuctionEntity.builder()
                 .auctionId(1L)
-                .userId("user1")
+                .userEmail("user1")
                 .itemName("item")
                 .startingPrice(1234)
                 .minimumBid(1000)
@@ -235,7 +234,7 @@ class AuctionServiceTest {
                 .endDateTime(LocalDateTime.of(2023,4,10,00,00,00))
                 .build();
 
-        given(auctionRepository.findByUserIdAndAuctionId(any(), anyLong()))
+        given(auctionRepository.findByUserEmailAndAuctionId(any(), anyLong()))
                 .willReturn(Optional.ofNullable(auctionEntity));
 
         //when
@@ -264,7 +263,7 @@ class AuctionServiceTest {
 
         AuctionEntity auctionEntity = AuctionEntity.builder()
                 .auctionId(1L)
-                .userId("user1")
+                .userEmail("user1")
                 .itemName("item")
                 .startingPrice(1234)
                 .minimumBid(1000)
@@ -275,7 +274,7 @@ class AuctionServiceTest {
                 .endDateTime(LocalDateTime.of(2023,4,10,00,00,00))
                 .build();
 
-        given(auctionRepository.findByUserIdAndAuctionId(any(), anyLong()))
+        given(auctionRepository.findByUserEmailAndAuctionId(any(), anyLong()))
                 .willReturn(Optional.ofNullable(auctionEntity));
 
         //when
@@ -294,7 +293,7 @@ class AuctionServiceTest {
         List<AuctionEntity> list = List.of(
                 AuctionEntity.builder()
                         .auctionId(1L)
-                        .userId("user1")
+                        .userEmail("user1")
                         .itemName("item1")
                         .startingPrice(1111)
                         .minimumBid(1000)
@@ -305,7 +304,7 @@ class AuctionServiceTest {
                         .build(),
                 AuctionEntity.builder()
                         .auctionId(2L)
-                        .userId("user1")
+                        .userEmail("user1")
                         .itemName("item2")
                         .startingPrice(2222)
                         .minimumBid(2000)
@@ -318,10 +317,10 @@ class AuctionServiceTest {
         );
         Page<AuctionEntity> page = new PageImpl<>(list);
 
-        given(auctionRepository.findByUserId(any(), any())).willReturn(page);
+        given(auctionRepository.findByUserEmail(any(), any())).willReturn(page);
 
         //when
-        var result = auctionService.getAllAuctionListByUserId("user1", Pageable.ofSize(10));
+        var result = auctionService.getAllAuctionListByUserEmail("user1", Pageable.ofSize(10));
 
         //then
         assertEquals(2, result.getTotalElements());
@@ -339,11 +338,11 @@ class AuctionServiceTest {
     @DisplayName("해당 유저의 모든 경매 리스트 가져오기 - 실패")
     void getAllAuctionListByUserIdFail(){
         //given
-        given(auctionRepository.findByUserId(any(), any())).willReturn(Page.empty());
+        given(auctionRepository.findByUserEmail(any(), any())).willReturn(Page.empty());
 
         //when
         AuctionException exception = assertThrows(AuctionException.class,
-                () -> auctionService.getAllAuctionListByUserId("user1", Pageable.ofSize(10)));
+                () -> auctionService.getAllAuctionListByUserEmail("user1", Pageable.ofSize(10)));
 
         //then
         assertEquals(NOT_FOUND_AUCTION_LIST, exception.getErrorCode());
@@ -356,7 +355,7 @@ class AuctionServiceTest {
         List<AuctionEntity> list = List.of(
                 AuctionEntity.builder()
                         .auctionId(1L)
-                        .userId("user1")
+                        .userEmail("user1")
                         .itemName("item1")
                         .startingPrice(1111)
                         .minimumBid(1000)
@@ -368,7 +367,7 @@ class AuctionServiceTest {
                         .build(),
                 AuctionEntity.builder()
                         .auctionId(2L)
-                        .userId("user1")
+                        .userEmail("user1")
                         .itemName("item2")
                         .startingPrice(2222)
                         .minimumBid(2000)
@@ -385,7 +384,7 @@ class AuctionServiceTest {
         given(auctionRepository.findByUserIdAndAuctionStatus(any(), any(), any())).willReturn(page);
 
         //when
-        var result = auctionService.getAuctionListByUserIdAndAuctionStatus("user1", AuctionStatus.SCHEDULED, Pageable.ofSize(10));
+        var result = auctionService.getAuctionListByUserEmailAndAuctionStatus("user1", AuctionStatus.SCHEDULED, Pageable.ofSize(10));
 
         //then
         assertEquals(2, result.getTotalElements());
@@ -409,7 +408,7 @@ class AuctionServiceTest {
 
         //when
         AuctionException exception = assertThrows(AuctionException.class,
-                () -> auctionService.getAuctionListByUserIdAndAuctionStatus("user1", AuctionStatus.COMPLETE, Pageable.ofSize(10)));
+                () -> auctionService.getAuctionListByUserEmailAndAuctionStatus("user1", AuctionStatus.COMPLETE, Pageable.ofSize(10)));
 
         //then
         assertEquals(AUCTION_NOT_FOUND, exception.getErrorCode());

--- a/a_uction/src/test/java/com/example/a_uction/service/UserModifyServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/UserModifyServiceTest.java
@@ -1,0 +1,120 @@
+package com.example.a_uction.service;
+
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.model.user.dto.ModifyUser;
+import com.example.a_uction.model.user.entity.UserEntity;
+import com.example.a_uction.model.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static com.example.a_uction.exception.constants.ErrorCode.ENTERED_THE_WRONG_PASSWORD;
+import static com.example.a_uction.exception.constants.ErrorCode.USER_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserModifyServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserModifyService userModifyService;
+
+    @Spy
+    private BCryptPasswordEncoder passwordEncoder;
+
+
+    @Test
+    @DisplayName("회원정보 수정 - 성공")
+    void modifyUserDetailSuccess() {
+        //given
+        UserEntity userEntity = UserEntity.builder()
+                .id(1L)
+                .userEmail("test@test.com")
+                .username("test")
+                .createDateTime(LocalDateTime.now())
+                .phoneNumber("01012341234")
+                .password(passwordEncoder.encode("1234"))
+                .build();
+
+        ModifyUser.Request updateUser = ModifyUser.Request.builder()
+                .currentPassword("1234")
+                .phone("01043214321")
+                .updatePassword("")
+                .username("test1")
+                .build();
+
+        given(userRepository.findByUserEmail(any())).willReturn(Optional.ofNullable(userEntity));
+        given(userRepository.save(any())).willReturn(userEntity);
+
+        //when
+        var result = userModifyService.modifyUserDetail("test@test.com", updateUser);
+
+        //then
+        assertEquals("test1", result.getUsername());
+        assertEquals("01043214321", result.getPhone());
+    }
+
+    @Test
+    @DisplayName("회원정보 수정 - 실패 - 사용자 정보 없음")
+    void modifyUserDetailFailUser() {
+        //given
+        ModifyUser.Request updateUser = ModifyUser.Request.builder()
+                .currentPassword("1234")
+                .phone("01043214321")
+                .updatePassword("")
+                .username("test1")
+                .build();
+
+        given(userRepository.findByUserEmail(any())).willThrow(new AuctionException(USER_NOT_FOUND));
+
+        //when
+        AuctionException exception = assertThrows(AuctionException.class,
+                () -> userModifyService.modifyUserDetail("test1@test.com", updateUser));
+
+        //then
+        assertEquals(USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("회원정보 수정 - 실패 - 현재 비밀번호 일치하지 않음")
+    void modifyUserDetailFailPassword() {
+        //given
+        UserEntity userEntity = UserEntity.builder()
+                .id(1L)
+                .userEmail("test@test.com")
+                .username("test")
+                .createDateTime(LocalDateTime.now())
+                .phoneNumber("01012341234")
+                .password(passwordEncoder.encode("1234"))
+                .build();
+
+        ModifyUser.Request updateUser = ModifyUser.Request.builder()
+                .currentPassword("4321")
+                .phone("01043214321")
+                .updatePassword("")
+                .username("test1")
+                .build();
+
+        given(userRepository.findByUserEmail(any())).willReturn(Optional.ofNullable(userEntity));
+
+        //when
+        AuctionException exception = assertThrows(AuctionException.class,
+                () -> userModifyService.modifyUserDetail("test1@test.com", updateUser));
+
+        //then
+        assertEquals(ENTERED_THE_WRONG_PASSWORD, exception.getErrorCode());
+    }
+}

--- a/auction-user-api.http
+++ b/auction-user-api.http
@@ -40,3 +40,16 @@ Content-Type: application/json
 GET http://localhost:8081/detail
 Content-Type: application/json
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZUBnbWFpbC5jb20iLCJpYXQiOjE2ODA5NjEwNTksImV4cCI6MTY4MTA0NzQ1OX0.YW0rzMRoYMZR_scQaQ4-OiKV4ZM0l4vAVpmnrUK5RWQ
+
+
+###회원정보 수정
+POST localhost:8081/user/detail/modify
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZUBnbWFpbC5jb20iLCJzdWIiOiJBY2Nlc3NUb2tlbiIsImlhdCI6MTY4MTA4MjMxNywiZXhwIjoxNjgxMDg1OTE3fQ.xCbOujpg7H0z7LxZQ6RKtz6LicuQn3D6Yrxaev_WaII
+
+{
+  "currentPassword" : "1234",
+  "updatePassword" : "",
+  "username" : "test",
+  "phone" : "01012341234"
+}


### PR DESCRIPTION
Change1
---
1. 회원정보 수정 내용
   1. userName : 개명시 필요
   2. phone
   3. password
2. userEmail 은 변경 불가능
3. 회원정보 수정은 현재 비밀번호와 일치 시 변경 가능
4. updatePassword 이 비여있으면 비밀번호 변경을 원하지 않으므로 기존 비밀번호 유지

Change2
---
1. ResponseEntity<?> 부분에서 ? 을 Response format 으로 변경
2. setUpdate 부분 삭제

Background
---
회원정보 수정 관련하여 FE 에게 회원정보 수정 Format 에 대해 inform 필요

closes #46 

