### PR TITLE
[feat/#45/verify] 회원가입 핸드폰번호 인증 구현 + 이메일중복체크 기능 구현 + 모든 서비스코드 작성

### DIFF
--- a/a_uction/build.gradle
+++ b/a_uction/build.gradle
@@ -24,7 +24,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+
+	// swagger
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
+
+	// restTemplate 관련
+	compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
+
+	// 난수발생
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
 
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/a_uction/src/main/java/com/example/a_uction/config/SmsVerifyConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/config/SmsVerifyConfig.java
@@ -1,0 +1,16 @@
+package com.example.a_uction.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+@Configuration
+public class SmsVerifyConfig {
+
+	@Bean
+	public HttpHeaders headers() {
+		return new HttpHeaders();
+	}
+
+}

--- a/a_uction/src/main/java/com/example/a_uction/controller/UserRegisterController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/UserRegisterController.java
@@ -1,9 +1,16 @@
 package com.example.a_uction.controller;
 
 import com.example.a_uction.model.user.dto.RegisterUser;
+import com.example.a_uction.model.user.dto.Verify;
 import com.example.a_uction.service.UserRegisterService;
+import com.example.a_uction.service.user.VerifyService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,10 +21,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/register")
 public class UserRegisterController {
 	private final UserRegisterService userRegisterService;
+	private final VerifyService verifyService;
 
 	@PostMapping
 	public ResponseEntity<RegisterUser> register(
 		@RequestBody RegisterUser.Request request) {
+
 		return ResponseEntity.ok(userRegisterService.register(request));
+	}
+
+	@GetMapping("/emailCheck")
+	public ResponseEntity<Boolean> emailCheck(@RequestBody String email) {
+
+		return ResponseEntity.ok(userRegisterService.emailCheck(email));
+	}
+
+	@PostMapping("/verify/sms")
+	public ResponseEntity<Verify.Response> sendVerifyMessage(
+		@RequestBody String phoneNumber)
+		throws NoSuchAlgorithmException, InvalidKeyException, URISyntaxException, JsonProcessingException {
+
+		return ResponseEntity.ok(verifyService.sendVerificationCode(phoneNumber));
+	}
+
+	@GetMapping("/verify/sms/codeCheck")
+	public ResponseEntity<Boolean> codeCheck(@RequestBody String code) {
+		return ResponseEntity.ok(verifyService.verifyCode(code));
 	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/controller/UserRegisterController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/UserRegisterController.java
@@ -45,7 +45,7 @@ public class UserRegisterController {
 	}
 
 	@GetMapping("/verify/sms/codeCheck")
-	public ResponseEntity<Boolean> codeCheck(@RequestBody String code) {
-		return ResponseEntity.ok(verifyService.verifyCode(code));
+	public ResponseEntity<Boolean> codeCheck(@RequestBody Verify.Form form) {
+		return ResponseEntity.ok(verifyService.verifyCode(form));
 	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
+++ b/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
@@ -1,6 +1,7 @@
 package com.example.a_uction.exception.constants;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,6 +18,8 @@ public enum ErrorCode {
 
 	INVALID_TOKEN(UNAUTHORIZED, "토큰이 만료되었습니다."),
 	USER_NOT_FOUND(BAD_REQUEST, "유저를 찾을 수 없습니다."),
+	THIS_PHONE_NUMBER_ALREADY_AUTHENTICATION(BAD_REQUEST, "이 번호는 이미 인증이 완료되었습니다."),
+	WRONG_CODE_INPUT(BAD_REQUEST, "코드를 잘못 입력하셨습니다. 처음부터 다시 시도해주세요."),
 	ENTERED_THE_WRONG_PASSWORD(BAD_REQUEST, "비밀번호를 확인 해 주세요."),
 	EMAIL_FORMAT_ERROR(BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
 	THIS_EMAIL_ALREADY_EXIST(BAD_REQUEST, "해당 이메일은 이미 존재합니다."),

--- a/a_uction/src/main/java/com/example/a_uction/model/user/dto/Verify.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/dto/Verify.java
@@ -1,0 +1,57 @@
+package com.example.a_uction.model.user.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class Verify {
+
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Setter
+	@Getter
+	public static class Message {
+
+		private String to;
+		private String content;
+	}
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Setter
+	@Getter
+	@Builder
+	public static class Request {
+
+		private String type;
+		private String contentType;
+		private String countryCode;
+		private String from;
+		private String content;
+		private List<Verify.Message> messages;
+	}
+
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor
+	@Getter
+	public static class Response {
+
+		private String requestId;
+		private LocalDateTime requestTime;
+		private String statusCode;
+		private String statusName;
+
+	}
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Setter
+	@Getter
+	public static class TestMessage {
+		private String phoneNumber;
+		private String content;
+	}
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/user/dto/Verify.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/dto/Verify.java
@@ -50,8 +50,8 @@ public class Verify {
 	@NoArgsConstructor
 	@Setter
 	@Getter
-	public static class TestMessage {
+	public static class Form {
 		private String phoneNumber;
-		private String content;
+		private String code;
 	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/model/user/entity/UserEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/entity/UserEntity.java
@@ -36,7 +36,6 @@ public class UserEntity {
 	private String password;
 	private String username;
 	private String phoneNumber;
-	private boolean verify;
 
 	@CreatedDate
 	private LocalDateTime createDateTime;

--- a/a_uction/src/main/java/com/example/a_uction/model/user/entity/UserVerificationEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/entity/UserVerificationEntity.java
@@ -1,0 +1,27 @@
+package com.example.a_uction.model.user.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserVerificationEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String phoneNumber;
+	private String code;
+}
+
+

--- a/a_uction/src/main/java/com/example/a_uction/model/user/repository/UserRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/repository/UserRepository.java
@@ -8,5 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 	Optional<UserEntity> findByUserEmail(String email);
+	Optional<UserEntity> findByPhoneNumber(String phoneNumber);
 	boolean existsByUserEmail(String email);
 }

--- a/a_uction/src/main/java/com/example/a_uction/model/user/repository/UserVerificationEntityRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/repository/UserVerificationEntityRepository.java
@@ -1,0 +1,11 @@
+package com.example.a_uction.model.user.repository;
+
+import com.example.a_uction.model.user.entity.UserVerificationEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserVerificationEntityRepository extends JpaRepository<UserVerificationEntity, Long> {
+	Optional<UserVerificationEntity> findByCode(String code);
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/user/repository/UserVerificationEntityRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/repository/UserVerificationEntityRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserVerificationEntityRepository extends JpaRepository<UserVerificationEntity, Long> {
-	Optional<UserVerificationEntity> findByCode(String code);
+	Optional<UserVerificationEntity> findByCodeAndPhoneNumber(String code, String phoneNumber);
 }

--- a/a_uction/src/main/java/com/example/a_uction/security/jwt/JwtProvider.java
+++ b/a_uction/src/main/java/com/example/a_uction/security/jwt/JwtProvider.java
@@ -86,7 +86,7 @@ public class JwtProvider {
 			Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
 			return true;
 		} catch (IllegalArgumentException e) {
-			log.info("토큰은 필수입니다.", e);
+			log.info("");
 		} catch (MalformedJwtException e) {
 			log.info("손상된 토큰입니다.", e);
 		} catch (ExpiredJwtException e) {

--- a/a_uction/src/main/java/com/example/a_uction/security/jwt/dto/TokenDto.java
+++ b/a_uction/src/main/java/com/example/a_uction/security/jwt/dto/TokenDto.java
@@ -10,18 +10,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TokenDto {
-	String accessToken;
-	String refreshToken;
+	private String accessToken;
+	private String refreshToken;
 
-	long refreshTokenExpireTime;
+	private Long refreshTokenExpireTime;
 
 	@Getter
 	@Builder
 	@NoArgsConstructor
 	@AllArgsConstructor
 	public static class AccessToken {
-		String accessToken;
-		String expiresIn;
-		String tokenType;
+		private String accessToken;
+		private String expiresIn;
+		private String tokenType;
 	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/service/UserRegisterService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/UserRegisterService.java
@@ -21,21 +21,20 @@ public class UserRegisterService {
 
 	public RegisterUser register(RegisterUser.Request request) {
 
-		registerValidate(request);
-
 		return RegisterUser.fromEntity(
 			userRepository.save(UserEntity.builder()
-			.username(request.getUsername())
-			.phoneNumber(request.getPhoneNumber())
-			.password(passwordEncoder.encode(request.getPassword()))
-			.userEmail(request.getUserEmail())
-			.build()));
+				.username(request.getUsername())
+				.phoneNumber(request.getPhoneNumber())
+				.password(passwordEncoder.encode(request.getPassword()))
+				.userEmail(request.getUserEmail())
+				.build()));
 	}
-	private void registerValidate(RegisterUser.Request request) {
-		if (userRepository.findByUserEmail(request.getUserEmail()).isPresent()) {
+
+	public boolean emailCheck(String email) {
+		if (userRepository.findByUserEmail(email).isPresent()) {
 			log.error("중복된 이메일 가입 시도");
 			throw new AuctionException(THIS_EMAIL_ALREADY_EXIST);
 		}
+		return true;
 	}
-
 }

--- a/a_uction/src/main/java/com/example/a_uction/service/user/VerifyService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/user/VerifyService.java
@@ -1,0 +1,152 @@
+package com.example.a_uction.service.user;
+
+import static com.example.a_uction.exception.constants.ErrorCode.THIS_PHONE_NUMBER_ALREADY_AUTHENTICATION;
+import static com.example.a_uction.exception.constants.ErrorCode.WRONG_CODE_INPUT;
+
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.model.user.dto.Verify;
+import com.example.a_uction.model.user.entity.UserVerificationEntity;
+import com.example.a_uction.model.user.repository.UserRepository;
+import com.example.a_uction.model.user.repository.UserVerificationEntityRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class VerifyService {
+
+	@Value("${sms.serviceId}")
+	private String serviceId;
+	@Value("${sms.accessKey}")
+	private String accessKey;
+	@Value("${sms.secretKey}")
+	private String secretKey;
+
+	private final ObjectMapper objectMapper;
+	private final HttpHeaders headers;
+	private final RestTemplate restTemplate;
+	private final UserRepository userRepository;
+	private final UserVerificationEntityRepository verificationEntityRepository;
+
+	public Verify.Response sendVerificationCode(String phoneNumber)
+		throws NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException, URISyntaxException {
+
+		validatePhoneNumber(phoneNumber);
+
+		String verifyCode = generateVerificationCode(phoneNumber);
+
+		Long time = System.currentTimeMillis();
+		String sendMessage = messageFormat(verifyCode);
+		List<Verify.Message> messages = new ArrayList<>();
+		messages.add((
+			new Verify.Message(phoneNumber, sendMessage)
+		));
+
+		Verify.Request request =
+			Verify.Request.builder()
+				.type("SMS")
+				.contentType("COMM")
+				.countryCode("82")
+				.from("01033538090")
+				.messages(messages)
+				.content(sendMessage)
+				.build();
+
+		String jsonBody = objectMapper.writeValueAsString(request);
+
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.set("x-ncp-apigw-timestamp", time.toString());
+		headers.set("x-ncp-iam-access-key", accessKey);
+		String signature = makeSignature(time);
+		headers.set("x-ncp-apigw-signature-v2", signature);
+
+		HttpEntity<String> body = new HttpEntity<>(jsonBody, headers);
+
+		restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+		restTemplate.setErrorHandler(new DefaultResponseErrorHandler());
+
+		return restTemplate.postForObject(
+			new URI("https://sens.apigw.ntruss.com/sms/v2/services/" + this.serviceId + "/messages"), body, Verify.Response.class
+		);
+	}
+	public boolean verifyCode(String code) {
+		if (verificationEntityRepository.findByCode(code).isEmpty()) {
+			throw new AuctionException(WRONG_CODE_INPUT);
+		}
+		deleteVerification(code);
+		return true;
+	}
+	private void validatePhoneNumber(String phoneNumber) {
+		if (userRepository.findByPhoneNumber(phoneNumber).isPresent()){
+			throw new AuctionException(THIS_PHONE_NUMBER_ALREADY_AUTHENTICATION);
+		}
+	}
+
+	private String generateVerificationCode(String phoneNumber) {
+		String verifyCode = RandomStringUtils.random(6, true, true);
+		verificationEntityRepository.save(UserVerificationEntity.builder()
+			.code(verifyCode)
+			.phoneNumber(phoneNumber)
+			.build());
+
+		return verifyCode;
+	}
+
+	private void deleteVerification(String code) {
+		Optional<UserVerificationEntity> user = verificationEntityRepository.findByCode(code);
+		user.ifPresent(verificationEntityRepository::delete);
+	}
+
+	private String messageFormat(String randomCode) {
+
+		return "[A+UCTION] 인증번호:"
+			+ randomCode
+			+ "\n"
+			+ "인증번호를 입력해 주세요.";
+	}
+
+	private String makeSignature(Long time)
+		throws NoSuchAlgorithmException, InvalidKeyException{
+
+
+		String message = "POST"
+			+ " "
+			+ "/sms/v2/services/" + serviceId + "/messages"
+			+ "\n"
+			+ time.toString()
+			+ "\n"
+			+ this.accessKey;
+
+		SecretKeySpec signingKey = new SecretKeySpec(
+			this.secretKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+		Mac mac = Mac.getInstance("HmacSHA256");
+		mac.init(signingKey);
+
+		byte[] rawHmac = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+
+		return Base64.encodeBase64String(rawHmac);
+	}
+}

--- a/a_uction/src/main/java/com/example/a_uction/service/user/VerifyService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/user/VerifyService.java
@@ -92,11 +92,12 @@ public class VerifyService {
 			new URI("https://sens.apigw.ntruss.com/sms/v2/services/" + this.serviceId + "/messages"), body, Verify.Response.class
 		);
 	}
-	public boolean verifyCode(String code) {
-		if (verificationEntityRepository.findByCode(code).isEmpty()) {
+	public boolean verifyCode(Verify.Form form) {
+		if (verificationEntityRepository
+			.findByCodeAndPhoneNumber(form.getCode(), form.getPhoneNumber()).isEmpty()) {
 			throw new AuctionException(WRONG_CODE_INPUT);
 		}
-		deleteVerification(code);
+		deleteVerification(form);
 		return true;
 	}
 	private void validatePhoneNumber(String phoneNumber) {
@@ -115,8 +116,10 @@ public class VerifyService {
 		return verifyCode;
 	}
 
-	private void deleteVerification(String code) {
-		Optional<UserVerificationEntity> user = verificationEntityRepository.findByCode(code);
+	private void deleteVerification(Verify.Form form) {
+		Optional<UserVerificationEntity> user =
+			verificationEntityRepository
+				.findByCodeAndPhoneNumber(form.getCode(), form.getPhoneNumber());
 		user.ifPresent(verificationEntityRepository::delete);
 	}
 

--- a/a_uction/src/test/java/com/example/a_uction/controller/UserRegisterControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/UserRegisterControllerTest.java
@@ -1,8 +1,10 @@
 package com.example.a_uction.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -12,6 +14,7 @@ import com.example.a_uction.exception.AuctionException;
 import com.example.a_uction.exception.constants.ErrorCode;
 import com.example.a_uction.model.user.dto.RegisterUser;
 import com.example.a_uction.service.UserRegisterService;
+import com.example.a_uction.service.user.VerifyService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +35,8 @@ class UserRegisterControllerTest {
 
 	@MockBean
 	private UserRegisterService userRegisterService;
+	@MockBean
+	private VerifyService verifyService;
 
 	@Autowired
 	private ObjectMapper objectMapper;
@@ -66,26 +71,70 @@ class UserRegisterControllerTest {
 	}
 	@Test
 	@WithMockUser
-	@DisplayName("회원가입 실패 - 컨트롤러 테스트")
-	void register_FAIL() throws Exception {
+	@DisplayName("이메일중복 확인 - 사용 가능")
+	void emailCheck_SUCCESS() throws Exception {
 		//given
-		given(userRegisterService.register(any()))
-			.willThrow(new AuctionException(ErrorCode.THIS_EMAIL_ALREADY_EXIST));
+		given(userRegisterService.emailCheck(anyString()))
+			.willReturn(true);
 		//when
 		//then
-		mockMvc.perform(post("/register")
+		mockMvc.perform(get("/register/emailCheck")
 				.with(csrf())
-				.content(objectMapper.writeValueAsString(
-					new RegisterUser.Request(
-						"zerobase@gmail.com",
-						"1234",
-						"zerobase",
-						"01012345678")
-				))
-				.contentType(MediaType.APPLICATION_JSON))
+				.content("zerobase@gmail.com"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andReturn().getResponse().toString().equals(true);
+	}
+	@Test
+	@WithMockUser
+	@DisplayName("이메일중복 확인 - 사용 불가")
+	void emailCheck_FAIL() throws Exception {
+	    //given
+		given(userRegisterService.emailCheck(anyString()))
+			.willThrow(new AuctionException(ErrorCode.THIS_EMAIL_ALREADY_EXIST));
+	    //when
+		//then
+		mockMvc.perform(get("/register/emailCheck")
+				.with(csrf())
+				.content("zerobase@gmail.com"))
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.errorCode").value("THIS_EMAIL_ALREADY_EXIST"))
 			.andExpect(jsonPath("$.message").value("해당 이메일은 이미 존재합니다."));
+	}
+
+	@Test
+	@WithMockUser
+	@DisplayName("인증완료 - 코드체크 성공")
+	void codeCheck_SUCCESS() throws Exception {
+	    //given
+		given(verifyService.verifyCode(anyString()))
+			.willReturn(true);
+	    //when
+	    //then
+		mockMvc.perform(get("/register/verify/sms/codeCheck")
+				.with(csrf())
+				.content("qwe123"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andReturn().getResponse().toString().equals(true);
+	}
+	@Test
+	@WithMockUser
+	@DisplayName("인증완료 - 코드체크 실패")
+	void codeCheck_FAIL() throws Exception {
+		//given
+		given(verifyService.verifyCode(anyString()))
+			.willThrow(new AuctionException(ErrorCode.WRONG_CODE_INPUT));
+		//when
+		//then
+		mockMvc.perform(get("/register/verify/sms/codeCheck")
+				.with(csrf())
+				.content("qwe123"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.errorCode").value("WRONG_CODE_INPUT"))
+			.andExpect(jsonPath("$.message")
+				.value("코드를 잘못 입력하셨습니다. 처음부터 다시 시도해주세요."));
 	}
 }

--- a/a_uction/src/test/java/com/example/a_uction/controller/UserRegisterControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/UserRegisterControllerTest.java
@@ -108,7 +108,7 @@ class UserRegisterControllerTest {
 	@DisplayName("인증완료 - 코드체크 성공")
 	void codeCheck_SUCCESS() throws Exception {
 	    //given
-		given(verifyService.verifyCode(anyString()))
+		given(verifyService.verifyCode(any()))
 			.willReturn(true);
 	    //when
 	    //then
@@ -124,7 +124,7 @@ class UserRegisterControllerTest {
 	@DisplayName("인증완료 - 코드체크 실패")
 	void codeCheck_FAIL() throws Exception {
 		//given
-		given(verifyService.verifyCode(anyString()))
+		given(verifyService.verifyCode(any()))
 			.willThrow(new AuctionException(ErrorCode.WRONG_CODE_INPUT));
 		//when
 		//then

--- a/a_uction/src/test/java/com/example/a_uction/service/UserLoginServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/UserLoginServiceTest.java
@@ -1,0 +1,101 @@
+package com.example.a_uction.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.exception.constants.ErrorCode;
+import com.example.a_uction.model.user.dto.LoginUser;
+import com.example.a_uction.model.user.entity.UserEntity;
+import com.example.a_uction.model.user.repository.UserRepository;
+import com.example.a_uction.security.jwt.JwtProvider;
+import com.example.a_uction.security.jwt.dto.TokenDto;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserLoginServiceTest {
+
+	@Mock
+	private JwtProvider provider;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@Mock
+	private BCryptPasswordEncoder passwordEncoder;
+
+	@InjectMocks
+	private UserLoginService userLoginService;
+
+	@Test
+	@DisplayName("로그인 성공")
+	void login_SUCCESS() {
+		// given
+		UserEntity user = UserEntity.builder()
+			.userEmail("zerobase@gmail.com")
+			.password("1234")
+			.build();
+		given(userRepository.findByUserEmail(anyString())).willReturn(Optional.of(user));
+		given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+		given(provider.createToken(anyString())).willReturn(
+			new TokenDto("123qwe", "qwe123", 1000L));
+		given(redisTemplate.opsForValue()).willReturn(mock(ValueOperations.class));
+		// when
+		TokenDto tokenDto = userLoginService.login(new LoginUser("zerobase@gmail.com", "1234"));
+
+		// then
+		assertNotNull(tokenDto);
+		assertEquals("123qwe", tokenDto.getAccessToken());
+		assertEquals("qwe123", tokenDto.getRefreshToken());
+		assertEquals(1000L, tokenDto.getRefreshTokenExpireTime());
+	}
+
+	@Test
+	@DisplayName("로그인 실패 - 비밀번호 잘못 입력")
+	void login_FAIL_WRONG_PASSWORD() {
+		// given
+		UserEntity user = UserEntity.builder()
+			.userEmail("zerobase@gmail.com")
+			.password("1234")
+			.build();
+		given(userRepository.findByUserEmail(anyString())).willReturn(Optional.of(user));
+		given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+		// when
+
+		AuctionException auctionException =
+			assertThrows(AuctionException.class,
+				() -> userLoginService.login(new LoginUser("zerobase@gmail.com", "2222")));
+		// then
+		assertEquals(ErrorCode.ENTERED_THE_WRONG_PASSWORD, auctionException.getErrorCode());
+	}
+
+	@Test
+	@DisplayName("로그인 실패 - 이메일 잘못 입력")
+	void login_FAIL_WRONG_EMAIL() {
+		// given
+		given(userRepository.findByUserEmail(anyString())).willReturn(Optional.empty());
+		// when
+
+		AuctionException auctionException =
+			assertThrows(AuctionException.class,
+				() -> userLoginService.login(new LoginUser("zerobase@gmail.com", "2222")));
+		// then
+		assertEquals(ErrorCode.USER_NOT_FOUND, auctionException.getErrorCode());
+	}
+}

--- a/auction-verify-api.http
+++ b/auction-verify-api.http
@@ -1,0 +1,16 @@
+### 이메일 중복체크 *** 회원가입 완료휴에는 false 반환
+GET http://localhost:8081/register/emailCheck
+
+zerobase@gmail.com
+
+### 핸드폰번호 인증하기 문자 발송 *** 본인번호로 한번씩 테스트 해보셔도 됩니다
+POST http://localhost:8081/register/verify/sms
+
+01033538090
+
+
+### 인증코드 입력하여 인증완료하기 *** 틀리면 오류메세지 반환
+GET http://localhost:8081/register/verify/sms/codeCheck
+
+jrK0oT
+

--- a/auction-verify-api.http
+++ b/auction-verify-api.http
@@ -3,14 +3,20 @@ GET http://localhost:8081/register/emailCheck
 
 zerobase@gmail.com
 
-### 핸드폰번호 인증하기 문자 발송 *** 본인번호로 한번씩 테스트 해보셔도 됩니다
+### 핸드폰번호 인증하기 문자 발송 *** 본인번호로 한번씩 테스트 해보셔도 됩니다 또한 이미 가입되어있는 번호면 에러메세지 반환
 POST http://localhost:8081/register/verify/sms
 
 01033538090
 
 
+
 ### 인증코드 입력하여 인증완료하기 *** 틀리면 오류메세지 반환
 GET http://localhost:8081/register/verify/sms/codeCheck
+Content-Type: application/json
 
-jrK0oT
+{
+  "phoneNumber": "01033538090",
+  "code": "IKMr03"
+}
+
 


### PR DESCRIPTION
Changes
---

회원가입 이메일중복체크 기능 구현
핸드폰번호 인증하기 구현 
관련해서 모든 테스트코드 구현

Background
---

FE에서 이메일 중복체크, 핸드폰번호 인증하기를 완료하여야 회원가입할 수 있도록 해야합니다
그렇기 때문에 userEntity 에서 verify 컬럼은 없어졌습니다.(핸드폰번호인증, 이메일중복체크를 먼저 진행해야 하기때문에 의미가 사라짐)
010XXXXXXXX ('-'빼고 입력) 하여 발송요청을 보내면 해당번호로 랜덤코드 날아오고 코드는 verification 테이블에 저장됩니다
해당하는 코드를 입력하고 요청하면 입력한 번호와 코드로 verificationRepository를 검사하고 없으면 에러를 반환합니다

closes #45 