### PR TITLE
feat : [feat/#67/ElasticSearch/0] elasticsearch 구현

### DIFF
--- a/a_uction/build.gradle
+++ b/a_uction/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	//elasticsearch
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/a_uction/src/main/java/com/example/a_uction/config/ElasticSearchConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/config/ElasticSearchConfig.java
@@ -1,0 +1,22 @@
+package com.example.a_uction.config;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+
+@Configuration
+@EnableElasticsearchRepositories
+public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
+
+    @Override
+    public RestHighLevelClient elasticsearchClient() {
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+                .connectedTo("localhost:9200")
+                .build();
+        return RestClients.create(clientConfiguration).rest();
+    }
+}

--- a/a_uction/src/main/java/com/example/a_uction/controller/auction/AuctionSearchController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/auction/AuctionSearchController.java
@@ -1,0 +1,79 @@
+package com.example.a_uction.controller.auction;
+
+
+import com.example.a_uction.model.auction.constants.Category;
+import com.example.a_uction.model.auction.constants.ItemStatus;
+import com.example.a_uction.model.auction.dto.AuctionDocumentResponse;
+import com.example.a_uction.model.auction.dto.SearchCondition;
+import com.example.a_uction.service.auction.AuctionSearchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/search")
+@RequiredArgsConstructor
+@Slf4j
+public class AuctionSearchController {
+
+    private final AuctionSearchService auctionSearchService;
+
+    //es 등록
+    @PostMapping("/auctionDocument/{auctionId}")
+    public ResponseEntity<Void> saveAuctionDocuments(@PathVariable Long auctionId){
+        auctionSearchService.saveAuctionDocuments(auctionId);
+        return ResponseEntity.ok().build();
+    }
+
+    //시작금액
+    @GetMapping("/auctions/startingPrice")
+    public ResponseEntity<List<AuctionDocumentResponse>> searchByNickname(@RequestParam int startingPrice, Pageable pageable){
+        return ResponseEntity.ok(auctionSearchService.findByStartingPrice(startingPrice,pageable));
+    }
+
+    //minimumBid
+    @GetMapping("/auctions/minimumBid")
+    public ResponseEntity<List<AuctionDocumentResponse>> searchByMinimumBid(@RequestParam int minimumBid, Pageable pageable){
+        return ResponseEntity.ok(auctionSearchService.findByMinimumBid(minimumBid,pageable));
+    }
+
+    //itemStatus
+    @GetMapping("/auctions/itemStatus")
+    public ResponseEntity<List<AuctionDocumentResponse>> searchByMinimumBid(@RequestParam ItemStatus itemStatus, Pageable pageable){
+        return ResponseEntity.ok(auctionSearchService.findByItemStatus(itemStatus,pageable));
+    }
+
+    //category
+    @GetMapping("/auctions/category")
+    public ResponseEntity<List<AuctionDocumentResponse>> searchByMinimumBid(@RequestParam Category category, Pageable pageable){
+        return ResponseEntity.ok(auctionSearchService.findByCategory(category,pageable));
+    }
+
+    //검색어 상태별
+    @GetMapping("/auctions")
+    public ResponseEntity<List<AuctionDocumentResponse>> searchByName(SearchCondition searchCondition, Pageable pageable){
+        return ResponseEntity.ok(auctionSearchService.searchByCondition(searchCondition,pageable));
+    }
+
+    //item
+    @GetMapping("/auctions/itemName/startWith")
+    public ResponseEntity<List<AuctionDocumentResponse>> searchByStartWithItemName(@RequestParam String itemName, Pageable pageable){
+        return ResponseEntity.ok(auctionSearchService.findByStartWithItemName(itemName,pageable));
+    }
+
+    //description match
+    @GetMapping("/auctions/description/matches")
+    public ResponseEntity<List<AuctionDocumentResponse>> searchByMatchesDescription(@RequestParam String description, Pageable pageable){
+        return ResponseEntity.ok(auctionSearchService.findByMatchesDescription(description,pageable));
+    }
+
+    //description contains
+    @GetMapping("/auctions/description/contains")
+    public ResponseEntity<List<AuctionDocumentResponse>> searchByContainsDescription(@RequestParam String description, Pageable pageable){
+        return ResponseEntity.ok(auctionSearchService.findByContainsDescription(description,pageable));
+    }
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/dto/AuctionDocumentResponse.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/dto/AuctionDocumentResponse.java
@@ -1,0 +1,37 @@
+package com.example.a_uction.model.auction.dto;
+
+
+import com.example.a_uction.model.auction.constants.Category;
+import com.example.a_uction.model.auction.constants.ItemStatus;
+import com.example.a_uction.model.auction.constants.TransactionStatus;
+import com.example.a_uction.model.auction.entity.AuctionDocument;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AuctionDocumentResponse {
+    private Long auctionId;
+    private String itemName;
+    private ItemStatus itemStatus;
+    private TransactionStatus transactionStatus;
+    private int startingPrice;
+    private int minimumBid;
+    private Category category;
+    private String description;
+
+    public static AuctionDocumentResponse from(AuctionDocument auctionDocument){
+        return AuctionDocumentResponse.builder()
+                .auctionId(auctionDocument.getId())
+                .itemName(auctionDocument.getItemName())
+                .itemStatus(auctionDocument.getItemStatus())
+                .transactionStatus(auctionDocument.getTransactionStatus())
+                .startingPrice(auctionDocument.getStartingPrice())
+                .minimumBid(auctionDocument.getMinimumBid())
+                .category(auctionDocument.getCategory())
+                .description(auctionDocument.getDescription())
+                .build();
+    }
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/dto/AuctionDto.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/dto/AuctionDto.java
@@ -36,6 +36,8 @@ public class AuctionDto {
         private LocalDateTime startDateTime;
         @NotNull(message = "경매 종료 시간을 입력하세요")
         private LocalDateTime endDateTime;
+        @NotNull(message = "상품 설명을 입력하세요")
+        private String description;
 
         public AuctionEntity toEntity(UserEntity user){
             return AuctionEntity.builder()
@@ -47,6 +49,7 @@ public class AuctionDto {
                     .startDateTime(this.startDateTime)
                     .endDateTime(this.endDateTime)
                     .category(this.category)
+                    .description((this.description))
                     .build();
         }
 
@@ -66,6 +69,7 @@ public class AuctionDto {
         private Category category;
         private LocalDateTime startDateTime;
         private LocalDateTime endDateTime;
+        private String description;
 
 
         public AuctionDto.Response fromEntity(AuctionEntity auctionEntity){
@@ -78,6 +82,7 @@ public class AuctionDto {
                     .category(auctionEntity.getCategory())
                     .startDateTime(auctionEntity.getStartDateTime())
                     .endDateTime(auctionEntity.getEndDateTime())
+                    .description(auctionEntity.getDescription())
                     .build();
         }
     }

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/dto/SearchCondition.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/dto/SearchCondition.java
@@ -1,0 +1,25 @@
+package com.example.a_uction.model.auction.dto;
+
+import com.example.a_uction.model.auction.constants.Category;
+import com.example.a_uction.model.auction.constants.ItemStatus;
+import com.example.a_uction.model.auction.constants.TransactionStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SearchCondition {
+
+    private Long auctionId;
+    private String userEmail;
+
+    private String itemName;
+
+    private ItemStatus itemStatus;
+    private TransactionStatus transactionStatus;
+
+    private int startingPrice;
+    private int minimumBid;
+    private Category category;
+
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionDocument.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionDocument.java
@@ -1,0 +1,51 @@
+package com.example.a_uction.model.auction.entity;
+
+import com.example.a_uction.model.auction.constants.Category;
+import com.example.a_uction.model.auction.constants.ItemStatus;
+import com.example.a_uction.model.auction.constants.TransactionStatus;
+import lombok.*;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+import javax.persistence.Id;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@Document(indexName = "auction")
+@Mapping(mappingPath = "elastic/auction-mapping.json")
+@Setting(settingPath = "elastic/auction-setting.json")
+public class AuctionDocument {
+    @Id
+    private Long id;
+    private String userEmail;
+
+    private String itemName;
+
+    private ItemStatus itemStatus;
+    private TransactionStatus transactionStatus;
+
+    private int startingPrice;
+    private int minimumBid;
+    private Category category;
+
+    private String description;
+
+    public static AuctionDocument from(AuctionEntity auctionEntity){
+        return AuctionDocument.builder()
+                .id(auctionEntity.getAuctionId())
+                .itemName(auctionEntity.getItemName())
+                .userEmail(auctionEntity.getUser().getUserEmail())
+                .itemStatus(auctionEntity.getItemStatus())
+                .transactionStatus(auctionEntity.getTransactionStatus())
+                .startingPrice(auctionEntity.getStartingPrice())
+                .minimumBid(auctionEntity.getMinimumBid())
+                .category(auctionEntity.getCategory())
+                .description(auctionEntity.getDescription())
+                .build();
+    }
+
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionEntity.java
@@ -57,4 +57,7 @@ public class AuctionEntity {
     @LastModifiedDate
     private LocalDateTime updateDateTime;
 
+    @NotNull(message = "상품 설명을 입력하세요")
+    private String description;
+
 }

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/repository/AuctionSearchQueryRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/repository/AuctionSearchQueryRepository.java
@@ -1,0 +1,97 @@
+package com.example.a_uction.model.auction.repository;
+
+
+import com.example.a_uction.model.auction.dto.SearchCondition;
+import com.example.a_uction.model.auction.entity.AuctionDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Repository
+@RequiredArgsConstructor
+public class AuctionSearchQueryRepository {
+
+    private final ElasticsearchOperations operations;
+
+    public List<AuctionDocument> findByCondition(SearchCondition searchCondition, Pageable pageable) {
+        CriteriaQuery query = createConditionCriteriaQuery(searchCondition).setPageable(pageable);
+
+        SearchHits<AuctionDocument> search = operations.search(query, AuctionDocument.class);
+        return search.stream()
+                .map(SearchHit::getContent)
+                .collect(Collectors.toList());
+    }
+
+    private CriteriaQuery createConditionCriteriaQuery(SearchCondition searchCondition) {
+        CriteriaQuery query = new CriteriaQuery(new Criteria());
+
+        if (searchCondition == null)
+            return query;
+
+        if (searchCondition.getAuctionId() != null)
+            query.addCriteria(Criteria.where("auctionId").is(searchCondition.getAuctionId()));
+
+        if(searchCondition.getStartingPrice() > 0)
+            query.addCriteria(Criteria.where("startingPrice").is(searchCondition.getStartingPrice()));
+
+        if(searchCondition.getMinimumBid() > 0)
+            query.addCriteria(Criteria.where("minimumBid").is(searchCondition.getMinimumBid()));
+
+        if(StringUtils.hasText(searchCondition.getItemName()))
+            query.addCriteria(Criteria.where("itemName").is(searchCondition.getItemName()));
+
+        if(StringUtils.hasText(searchCondition.getUserEmail()))
+            query.addCriteria(Criteria.where("userEmail").is(searchCondition.getUserEmail()));
+
+        if(searchCondition.getItemStatus() != null)
+            query.addCriteria(Criteria.where("itemStatus").is(searchCondition.getItemStatus()));
+
+        if(searchCondition.getTransactionStatus() != null)
+            query.addCriteria(Criteria.where("transactionStatus").is(searchCondition.getTransactionStatus()));
+
+        if(searchCondition.getCategory() != null)
+            query.addCriteria(Criteria.where("category").is(searchCondition.getCategory()));
+
+        return query;
+    }
+
+    public List<AuctionDocument> findByStartWithItemName(String itemName, Pageable pageable) {
+        Criteria criteria = Criteria.where("itemName").startsWith(itemName);
+        Query query = new CriteriaQuery(criteria).setPageable(pageable);
+        SearchHits<AuctionDocument> search = operations.search(query, AuctionDocument.class);
+        return search.stream()
+                .map(SearchHit::getContent)
+                .collect(Collectors.toList());
+    }
+
+    // description 이 매칭되는 것들에 맞게 score 계산해서 찾아준다.
+    public List<AuctionDocument> findByMatchesDescription(String description, Pageable pageable) {
+        Criteria criteria = Criteria.where("description").matches(description);
+        Query query = new CriteriaQuery(criteria).setPageable(pageable);
+        SearchHits<AuctionDocument> search = operations.search(query, AuctionDocument.class);
+        return search.stream()
+                .map(SearchHit::getContent)
+                .collect(Collectors.toList());
+    }
+
+    public List<AuctionDocument> findByContainsDescription(String description, Pageable pageable) {
+        Criteria criteria = Criteria.where("description").contains(description);
+        Query query = new CriteriaQuery(criteria).setPageable(pageable);
+        SearchHits<AuctionDocument> search = operations.search(query, AuctionDocument.class);
+        return search.stream()
+                .map(SearchHit::getContent)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/repository/AuctionSearchRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/repository/AuctionSearchRepository.java
@@ -1,0 +1,18 @@
+package com.example.a_uction.model.auction.repository;
+
+import com.example.a_uction.model.auction.constants.Category;
+import com.example.a_uction.model.auction.constants.ItemStatus;
+import com.example.a_uction.model.auction.entity.AuctionDocument;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AuctionSearchRepository extends ElasticsearchRepository<AuctionDocument,Long> {
+    List<AuctionDocument> findByStartingPrice(int startingPrice, Pageable pageable);
+    List<AuctionDocument> findByMinimumBid(int minimumBid, Pageable pageable);
+    List<AuctionDocument> findByItemStatus(ItemStatus itemStatus, Pageable pageable);
+    List<AuctionDocument> findByCategory (Category category, Pageable pageable);
+}

--- a/a_uction/src/main/java/com/example/a_uction/security/config/SecurityConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/security/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
 			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			.and()
 				.authorizeRequests()
-					.antMatchers("/login/**", "/register/**", "/oauth/**").permitAll()
+					.antMatchers("/login/**", "/register/**", "/oauth/**", "/search/**").permitAll()
        			.antMatchers("/**").permitAll()
 			.and()
 				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/a_uction/src/main/java/com/example/a_uction/security/jwt/JwtAuthenticationFilter.java
+++ b/a_uction/src/main/java/com/example/a_uction/security/jwt/JwtAuthenticationFilter.java
@@ -85,6 +85,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				path.contains("register") ||
 				path.isEmpty() ||
 				path.equals("/auth/refresh") ||
+				path.contains("search") ||
 				path.equals("/");
 	}
 

--- a/a_uction/src/main/java/com/example/a_uction/service/auction/AuctionSearchService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/auction/AuctionSearchService.java
@@ -1,0 +1,96 @@
+package com.example.a_uction.service.auction;
+
+
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.model.auction.constants.Category;
+import com.example.a_uction.model.auction.constants.ItemStatus;
+import com.example.a_uction.model.auction.dto.AuctionDocumentResponse;
+import com.example.a_uction.model.auction.dto.SearchCondition;
+import com.example.a_uction.model.auction.entity.AuctionDocument;
+import com.example.a_uction.model.auction.repository.AuctionRepository;
+import com.example.a_uction.model.auction.repository.AuctionSearchQueryRepository;
+import com.example.a_uction.model.auction.repository.AuctionSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.a_uction.exception.constants.ErrorCode.AUCTION_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuctionSearchService {
+
+    private final AuctionRepository auctionRepository;
+    private final AuctionSearchRepository auctionSearchRepository;
+    private final AuctionSearchQueryRepository auctionSearchQueryRepository;
+
+    @Transactional
+    public void saveAuctionDocuments(Long auctionId) {
+        AuctionDocument result = auctionRepository.findById(auctionId).map(AuctionDocument::from)
+                .orElseThrow(() -> new AuctionException(AUCTION_NOT_FOUND));
+        auctionSearchRepository.save(result);
+    }
+
+
+    public List<AuctionDocumentResponse> findByStartingPrice(int startingPrice, Pageable pageable) {
+        return auctionSearchRepository.findByStartingPrice(startingPrice, pageable)
+                .stream()
+                .map(AuctionDocumentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<AuctionDocumentResponse> findByMinimumBid(int minimumBid, Pageable pageable) {
+        return auctionSearchRepository.findByMinimumBid(minimumBid, pageable)
+                .stream()
+                .map(AuctionDocumentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<AuctionDocumentResponse> findByItemStatus(ItemStatus itemStatus, Pageable pageable) {
+        return auctionSearchRepository.findByItemStatus(itemStatus, pageable)
+                .stream()
+                .map(AuctionDocumentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<AuctionDocumentResponse> findByCategory(Category category, Pageable pageable) {
+        return auctionSearchRepository.findByCategory(category, pageable)
+                .stream()
+                .map(AuctionDocumentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<AuctionDocumentResponse> searchByCondition(SearchCondition searchCondition, Pageable pageable) {
+        return auctionSearchQueryRepository.findByCondition(searchCondition, pageable)
+                .stream()
+                .map(AuctionDocumentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<AuctionDocumentResponse> findByStartWithItemName(String itemName, Pageable pageable) {
+        return auctionSearchQueryRepository.findByStartWithItemName(itemName, pageable)
+                .stream()
+                .map(AuctionDocumentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<AuctionDocumentResponse> findByMatchesDescription(String description, Pageable pageable) {
+        return auctionSearchQueryRepository.findByMatchesDescription(description, pageable)
+                .stream()
+                .map(AuctionDocumentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<AuctionDocumentResponse> findByContainsDescription(String description, Pageable pageable) {
+        return auctionSearchQueryRepository.findByContainsDescription(description, pageable)
+                .stream()
+                .map(AuctionDocumentResponse::from)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/a_uction/src/main/resources/elastic/auction-mapping.json
+++ b/a_uction/src/main/resources/elastic/auction-mapping.json
@@ -1,0 +1,17 @@
+{
+  "properties" : {
+    "auctionId" : {"type" : "keyword"},
+    "userEmail" : {"type" : "keyword"},
+    "itemName" : {"type" : "keyword"},
+    "itemStatus" : {"type" : "text"},
+    "transactionStatus" : {"type" : "keyword"},
+    "startingPrice" : {"type" : "keyword"},
+    "minimumBid" : {"type" : "keyword"},
+    "category" : {"type" : "keyword"},
+
+    "description" : {
+      "type" : "text",
+      "analyzer" : "korean"
+    }
+  }
+}

--- a/a_uction/src/main/resources/elastic/auction-setting.json
+++ b/a_uction/src/main/resources/elastic/auction-setting.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "analyzer": {
+      "korean": {
+        "type": "nori"
+      }
+    }
+  }
+}

--- a/auction-api.http
+++ b/auction-api.http
@@ -1,16 +1,17 @@
 ###경매 생성
 POST http://localhost:8081/auctions
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZUBnbWFpbC5jb20iLCJzdWIiOiJBY2Nlc3NUb2tlbiIsImlhdCI6MTY4MTI4OTE5NywiZXhwIjoxNjgxMjkyNzk3fQ.nh01Laz3Zrj2RiZdarN4ETRb_4rZgp6MY9MPegDRF3E
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZUBnbWFpbC5jb20iLCJzdWIiOiJBY2Nlc3NUb2tlbiIsImlhdCI6MTY4MTM3OTUyNiwiZXhwIjoxNjgxMzgzMTI2fQ.mNtb6GIpLPX_swZ92wilu07qizsv5-luE-xkT6HyeLw
 
 {
-  "itemName": "air force 1",
+  "itemName": "i-pod 1",
   "itemStatus": "GOOD",
   "startingPrice": 1000,
   "minimumBid": 100,
-  "category": "SHOES",
+  "category": "ETC",
   "startDateTime": "2024-04-11T13:41:30.416Z",
-  "endDateTime": "2024-04-30T13:41:30.416Z"
+  "endDateTime": "2024-04-30T13:41:30.416Z",
+  "description" : "this is i-pod 이것은 아이팟 입니다. 애플 애플 애플이다."
 }
 
 ###경매 보기

--- a/elastic-search.http
+++ b/elastic-search.http
@@ -1,0 +1,24 @@
+###es save
+POST http://localhost:8081/search/auctionDocument/2
+
+###Starting Price
+GET http://localhost:8081/search/auctions/startingPrice?startingPrice=1000&size=10
+
+###minimumBid
+GET http://localhost:8081/search/auctions/minimumBid?minimumBid=100&size=10
+
+###itemStatus
+GET http://localhost:8081/search/auctions/itemStatus?itemStatus=GOOD&size=10
+
+###category
+GET http://localhost:8081/search/auctions/category?category=SHOES&size=10
+
+###SearchCondition
+GET http://localhost:8081/search/auctions?category=ETC&itemStatus=BAD&size=10
+
+###description match
+GET http://localhost:8081/search/auctions/description/matches?description=애플&size=10
+
+###description contains
+GET http://localhost:8081/search/auctions/description/contains?description=애플&size=10
+


### PR DESCRIPTION
Change
---

1. 상품명, 상품상태, 카테고리, 시작금액, 최소비딩금액, description 검색 가능
2. AuctionEntity description 추가
3. isPass 에 path.contains("search") 추가
4. create auction 후 /search/auctionDocument/{auctionId} 이용하여 es 저장 후 해당 auction 에 대해 검색 가능

Background
---
1. auction create 할 때 자동으로 es 저장 가능 하도록 구현 필요
2. auction delete 할 때 해당 es 삭제 기능 필요
3. auction update 할 때 해당 es 업데이트 필요 (중복한 id 면 최신 data 로 update 되는데 해당 방식으로 사용해도 되는지 확인 필요)


To reviewer
---
docker 에 elastic search 설치 부탁 드립니다.
설치가 안되어 있으면 전체 실행이 안됩니다....
[설치 참고 링크](https://velog.io/@backtony/Spring-Data-Elasticsearch-%EC%97%B0%EB%8F%99-%EB%B0%8F-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%9E%91%EC%84%B1%ED%95%98%EA%B8%B0)

지금 저희 db 에서 **_ddl-auto: create_** 를 통해서 프로그램 실행시 전체 db 를 drop 후 Create 해서 사용하지만 elastic 경우 같은 기능이 있는지 모르겠습니다. 현재 코드에서는 db 에 값은 없어도 elastic 서버에 값이 저장되어 있으면 검색이 가능합니다.

closes #67 