### PR TITLE
[Feat/#59/chat 0] WebSocket 설정과 메세지가 오가는 flow 구현

### DIFF
--- a/a_uction/build.gradle
+++ b/a_uction/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 
 	// websocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	implementation 'org.springframework.boot:spring-boot-starter-reactor-netty'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'

--- a/a_uction/build.gradle
+++ b/a_uction/build.gradle
@@ -25,6 +25,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 
+	// websocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 

--- a/a_uction/src/main/java/com/example/a_uction/config/ChatInterceptor.java
+++ b/a_uction/src/main/java/com/example/a_uction/config/ChatInterceptor.java
@@ -1,0 +1,44 @@
+package com.example.a_uction.config;
+
+import com.example.a_uction.security.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHeaders;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChatInterceptor implements ChannelInterceptor {
+
+	private final JwtProvider provider;
+
+	@Value("${jwt.prefix}")
+	private String tokenPrefix;
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+		if (accessor.getCommand() == StompCommand.CONNECT) {
+
+			String authorization = String.valueOf(
+				accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION));
+
+			String token = authorization.substring(tokenPrefix.length());
+
+			provider.validateToken(token);
+
+			SecurityContextHolder.getContext()
+				.setAuthentication(provider.getAuthentication(token));
+		}
+
+		return message;
+	}
+}

--- a/a_uction/src/main/java/com/example/a_uction/config/WebSocketConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/config/WebSocketConfig.java
@@ -1,0 +1,41 @@
+package com.example.a_uction.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final ChatInterceptor interceptor;
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry
+			.addEndpoint("/ws")
+			.setAllowedOriginPatterns("*");
+//			.withSockJS(); //websocket 을 지원하지 않는 브라우저는 SockJs 를 사용한다는 뜻 적용하면 테스트 불가
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.setApplicationDestinationPrefixes("/pub")
+			.enableStompBrokerRelay("/topic")
+			.setRelayHost("127.0.0.1")
+			.setVirtualHost("/")
+			.setRelayPort(61613)
+			.setClientLogin("guest")
+			.setClientPasscode("guest");
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(interceptor);
+	}
+
+}

--- a/a_uction/src/main/java/com/example/a_uction/controller/chat/ChatController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/chat/ChatController.java
@@ -1,0 +1,27 @@
+package com.example.a_uction.controller.chat;
+
+import com.example.a_uction.model.chat.dto.ChatMessage;
+import com.example.a_uction.service.chat.ChatMessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class ChatController {
+
+	private final ChatMessageService chatMessageService;
+	@MessageMapping("/send")
+	public void sendMessage(@Payload ChatMessage message) {
+		chatMessageService.sendChatMessage(message);
+	}
+
+	@MessageMapping("/bid")
+	public Long bidding(@Payload ChatMessage message) {
+		return chatMessageService.bidding(message);
+	}
+
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/chat/constants/MessageType.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/chat/constants/MessageType.java
@@ -1,0 +1,8 @@
+package com.example.a_uction.model.chat.constants;
+
+import lombok.Getter;
+
+@Getter
+public enum MessageType {
+	ENTER, SEND, BIDDING
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/chat/dto/ChatMessage.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/chat/dto/ChatMessage.java
@@ -1,0 +1,20 @@
+package com.example.a_uction.model.chat.dto;
+
+import com.example.a_uction.model.chat.constants.MessageType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatMessage {
+	private MessageType messageType;
+	private String sender;
+	private String chatRoomId;
+	private String message;
+}

--- a/a_uction/src/main/java/com/example/a_uction/security/config/SecurityConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/security/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
 			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			.and()
 				.authorizeRequests()
-					.antMatchers("/login/**", "/register/**", "/oauth/**", "/search/**").permitAll()
+					.antMatchers("/login/**", "/register/**", "/oauth/**", "/ws").permitAll()
        			.antMatchers("/**").permitAll()
 			.and()
 				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/a_uction/src/main/java/com/example/a_uction/security/jwt/JwtAuthenticationFilter.java
+++ b/a_uction/src/main/java/com/example/a_uction/security/jwt/JwtAuthenticationFilter.java
@@ -33,6 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtProvider provider;
 	private final RedisTemplate<String, Object> redisTemplate;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -83,6 +84,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			path.contains("login") ||
 				path.contains("kakao") ||
 				path.contains("register") ||
+				path.contains("ws") ||
 				path.isEmpty() ||
 				path.equals("/auth/refresh") ||
 				path.contains("search") ||
@@ -98,6 +100,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		response.setContentType("application/json");
 		response.setCharacterEncoding("utf-8");
 
-		new ObjectMapper().writeValue(response.getWriter(), ErrorResponse.from(errorCode));
+		objectMapper.writeValue(response.getWriter(), ErrorResponse.from(errorCode));
 	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/service/chat/ChatMessageService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/chat/ChatMessageService.java
@@ -1,0 +1,51 @@
+package com.example.a_uction.service.chat;
+
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.exception.constants.ErrorCode;
+import com.example.a_uction.model.chat.constants.MessageType;
+import com.example.a_uction.model.chat.dto.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatMessageService {
+	private static final String ENTER_MESSAGE = "님이 입장하셨습니다.";
+
+	private final SimpMessageSendingOperations simpMessageSendingOperations;
+
+	public void sendChatMessage(ChatMessage chatMessage) {
+
+		if (chatMessage.getMessageType().equals(MessageType.ENTER)) {
+			chatMessage.setMessage(chatMessage.getSender() + ENTER_MESSAGE);
+			simpMessageSendingOperations
+				.convertAndSend("/topic/" + chatMessage.getChatRoomId(), chatMessage);
+		} else {
+			simpMessageSendingOperations
+				.convertAndSend("/topic/" + chatMessage.getChatRoomId(), chatMessage);
+		}
+	}
+
+	public Long bidding(ChatMessage message) {
+
+		Long bidPrice = Long.parseLong(message.getMessage());
+
+		validateBidding(bidPrice);
+
+		simpMessageSendingOperations
+			.convertAndSend("/topic/" + message.getChatRoomId(), message);
+
+		return bidPrice;
+	}
+
+	private void validateBidding(Long bidPrice) {
+
+		if (1000 > bidPrice) {
+			throw new AuctionException(ErrorCode.BEFORE_START_TIME);
+		}
+
+	}
+}


### PR DESCRIPTION
*Change*
---

메세지 관련 dto 들과 websocket, rabbitmq 설정
build.gradle 업데이트, 

*BackGround*
---

경매가 시작되면 
채팅방이 두개가 생성됩니다 ( bid, chat)

예를들어, auctionId = 1 인 경매에 참여한 유저들은
chat1 과 bid1 채팅방을 구독하게 됩니다.

messageType 별 메세지형태
ENTER : XXX님이 입장하셨습니다. 를 메세지채팅방으로 발행합니다. (String message 를 null 로 요청해도 됩니다)
BIDDING : 숫자만 입력가능합니다. bid채팅방으로 보내면 숫자만 파싱하여 입찰히스토리를 저장합니다.(아직 미구현)
SEND : 메세지를 입력하여 보내면 메세지 채팅방으로 발행합니다.

