### PR TITLE
feat : [feat/#59/chat-1] websocket configuration & chat 구현

### DIFF
--- a/a_uction/src/main/java/com/example/a_uction/config/RedisConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -20,6 +21,22 @@ public class RedisConfig {
 		redisTemplate.setValueSerializer(serializer);
 		redisTemplate.setHashKeySerializer(serializer);
 		redisTemplate.setHashValueSerializer(serializer);
+		return redisTemplate;
+	}
+
+	@Bean
+	public RedisTemplate<String, Integer> chatRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+
+		RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(
+			new GenericToStringSerializer<>(Integer.class));
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashValueSerializer(
+			new GenericToStringSerializer<>(Integer.class));
+
 		return redisTemplate;
 	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/controller/chat/ChatController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/chat/ChatController.java
@@ -1,11 +1,13 @@
 package com.example.a_uction.controller.chat;
 
-import com.example.a_uction.model.chat.dto.ChatMessage;
+import com.example.a_uction.model.chat.dto.Message;
 import com.example.a_uction.service.chat.ChatMessageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -14,14 +16,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
 
 	private final ChatMessageService chatMessageService;
-	@MessageMapping("/send")
-	public void sendMessage(@Payload ChatMessage message) {
+
+	@MessageMapping("/chatting")
+	public void sendMessage(@Payload Message message) {
 		chatMessageService.sendChatMessage(message);
 	}
 
-	@MessageMapping("/bid")
-	public Long bidding(@Payload ChatMessage message) {
+	@MessageMapping("/bidding")
+	public Long bidding(@Payload Message message) {
 		return chatMessageService.bidding(message);
 	}
 
+	@GetMapping("/{chatRoomId}/getConnectedUsers")
+	public Integer getUsers(@PathVariable String chatRoomId) {
+		return chatMessageService.getUsers(chatRoomId);
+	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/model/chat/dto/Message.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/chat/dto/Message.java
@@ -12,9 +12,9 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class ChatMessage {
+public class Message {
 	private MessageType messageType;
 	private String sender;
 	private String chatRoomId;
-	private String message;
+	private String contents;
 }

--- a/a_uction/src/main/java/com/example/a_uction/service/chat/ChatApplication.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/chat/ChatApplication.java
@@ -1,0 +1,60 @@
+package com.example.a_uction.service.chat;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Service
+@RequiredArgsConstructor
+public class ChatApplication {
+
+	private final RedisTemplate<String, Integer> chatRedisTemplate;
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	private static final String DESTINATION_HEADER = "simpDestination";
+	private static final String SESSION_ID_HEADER = "simpSessionId";
+
+	@EventListener(SessionConnectEvent.class)
+	public void onConnection (SessionConnectEvent connectEvent) {
+		String chatRoomId =
+			Objects.requireNonNull(
+					connectEvent.getMessage().getHeaders().get(DESTINATION_HEADER))
+				.toString()
+				.split("/")[2];
+
+		redisTemplate.opsForValue()
+			.set(Objects.requireNonNull(
+				connectEvent.getMessage().getHeaders().get(SESSION_ID_HEADER)).toString(), chatRoomId);
+
+		int count =
+			chatRedisTemplate.opsForValue().get(chatRoomId) != null ? Objects.requireNonNull(
+				chatRedisTemplate.opsForValue().get(chatRoomId)) + 1 : 1;
+
+		setData(chatRoomId, count);
+	}
+	@EventListener(SessionDisconnectEvent.class)
+	public void onConnection (SessionDisconnectEvent disconnectEvent) {
+
+		String chatRoomId = String.valueOf(
+			redisTemplate.opsForValue().getAndDelete(disconnectEvent.getSessionId()));
+
+		int count = Objects.requireNonNull(
+			chatRedisTemplate.opsForValue().get(chatRoomId)) - 1;
+
+		this.setData(chatRoomId, count);
+	}
+	private void setData(String chatRoomId, int count) {
+		if (count < 1) {
+			redisTemplate.delete(chatRoomId);
+		} else {
+			chatRedisTemplate.opsForValue().set(chatRoomId, count);
+		}
+	}
+	public Integer getUsers(String chatRoomId) {
+		return chatRedisTemplate.opsForValue().get(chatRoomId);
+	}
+}

--- a/a_uction/src/main/java/com/example/a_uction/service/chat/ChatMessageService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/chat/ChatMessageService.java
@@ -3,7 +3,7 @@ package com.example.a_uction.service.chat;
 import com.example.a_uction.exception.AuctionException;
 import com.example.a_uction.exception.constants.ErrorCode;
 import com.example.a_uction.model.chat.constants.MessageType;
-import com.example.a_uction.model.chat.dto.ChatMessage;
+import com.example.a_uction.model.chat.dto.Message;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -14,31 +14,37 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class ChatMessageService {
 	private static final String ENTER_MESSAGE = "님이 입장하셨습니다.";
+	private static final String DESTINATION = "/topic/";
 
 	private final SimpMessageSendingOperations simpMessageSendingOperations;
+	private final ChatApplication chatApplication;
 
-	public void sendChatMessage(ChatMessage chatMessage) {
+	public void sendChatMessage(Message message) {
 
-		if (chatMessage.getMessageType().equals(MessageType.ENTER)) {
-			chatMessage.setMessage(chatMessage.getSender() + ENTER_MESSAGE);
+		if (message.getMessageType().equals(MessageType.ENTER)) {
+			message.setContents(message.getSender() + ENTER_MESSAGE);
 			simpMessageSendingOperations
-				.convertAndSend("/topic/" + chatMessage.getChatRoomId(), chatMessage);
+				.convertAndSend(DESTINATION + message.getChatRoomId(), message);
 		} else {
 			simpMessageSendingOperations
-				.convertAndSend("/topic/" + chatMessage.getChatRoomId(), chatMessage);
+				.convertAndSend(DESTINATION + message.getChatRoomId(), message);
 		}
 	}
 
-	public Long bidding(ChatMessage message) {
+	public Long bidding(Message message) {
 
-		Long bidPrice = Long.parseLong(message.getMessage());
+		Long bidPrice = Long.parseLong(message.getContents());
 
 		validateBidding(bidPrice);
 
 		simpMessageSendingOperations
-			.convertAndSend("/topic/" + message.getChatRoomId(), message);
+			.convertAndSend(DESTINATION + message.getChatRoomId(), message);
 
 		return bidPrice;
+	}
+
+	public Integer getUsers(String chatRoomId) {
+		return chatApplication.getUsers(chatRoomId);
 	}
 
 	private void validateBidding(Long bidPrice) {

--- a/a_uction/src/test/java/com/example/a_uction/controller/auction/AuctionControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/auction/AuctionControllerTest.java
@@ -55,7 +55,6 @@ class AuctionControllerTest {
 	@Autowired
 	private ObjectMapper objectMapper;
 
-
 	@Test
 	@DisplayName("경매 생성 성공")
 	@WithMockUser
@@ -89,7 +88,6 @@ class AuctionControllerTest {
 			.andExpect(jsonPath("$.itemName").value("test item2"))
 			.andDo(print());
 	}
-
 
 	@Test
 	@WithMockUser

--- a/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionServiceTest.java
@@ -59,8 +59,8 @@ class AuctionServiceTest {
 				.itemStatus(ItemStatus.BAD)
 				.startingPrice(2000)
 				.minimumBid(200)
-				.startDateTime(LocalDateTime.parse("2023-04-15T17:09:42.411"))
-				.endDateTime(LocalDateTime.parse("2023-04-15T17:10:42.411"))
+				.startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
+				.endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
 				.build());
 		given(userRepository.getByUserEmail(any()))
 				.willReturn(UserEntity.builder()
@@ -73,8 +73,8 @@ class AuctionServiceTest {
 				.itemStatus(ItemStatus.GOOD)
 				.startingPrice(1000)
 				.minimumBid(100)
-				.startDateTime(LocalDateTime.parse("2023-04-15T17:09:42.411"))
-				.endDateTime(LocalDateTime.parse("2023-04-15T17:10:42.411"))
+				.startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
+				.endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
 				.build(), "user1");
 		//then
 		ArgumentCaptor<AuctionEntity> captor = ArgumentCaptor.forClass(AuctionEntity.class);
@@ -87,8 +87,8 @@ class AuctionServiceTest {
 		assertEquals(2000, response.getStartingPrice());
 		assertEquals(100, captor.getValue().getMinimumBid());
 		assertEquals(200, response.getMinimumBid());
-		assertEquals(LocalDateTime.parse("2023-04-15T17:09:42.411"), response.getStartDateTime());
-		assertEquals(LocalDateTime.parse("2023-04-15T17:10:42.411"), response.getEndDateTime());
+		assertEquals(LocalDateTime.parse("2025-04-15T17:09:42.411"), response.getStartDateTime());
+		assertEquals(LocalDateTime.parse("2025-04-15T17:10:42.411"), response.getEndDateTime());
 	}
 
 	@Test


### PR DESCRIPTION
Change
---

MessageDto 이름 변경
sub url 변경
Configuration 수정
채팅방 유저 수 확인을 위해 redisTemplate 추가
채팅방 구독, 구독취소 때마다 인원수 실시간 변경 가능

BackGround
---

Message 채팅방에 Connect 당시 해당 sessionId 를 Key로 chatRoomId 와 매핑하여 데이터 생성합니다.
Disconnect 시 데이터에서 sessionid로 chatRoomId 를찾고 동시에 데이터를 삭제합니다.
chatRoom 안에 있는 유저수에 -1 을 합니다.
유저수가 0이됐을때 자동으로 데이터를 사라지게 했습니다.


closes #59 