### PR TITLE
feature : [feat/#102/user-profile-image-0] 유저프로필이미지 등록, 수정, 삭제 기능구현

### DIFF
--- a/a_uction/src/main/java/com/example/a_uction/controller/user/UserInfoController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/user/UserInfoController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,4 +28,13 @@ public class UserInfoController {
 		return ResponseEntity.ok(userInfoService.userInfo(principal.getName()));
 	}
 
+	@PostMapping("/modify/profile-image")
+	public ResponseEntity<InfoUser> modifyProfileImage(@RequestPart MultipartFile file, Principal principal) {
+		return ResponseEntity.ok(userInfoService.modifyProfileImage(file, principal.getName()));
+	}
+
+	@PutMapping("/delete/profile-image")
+	public ResponseEntity<InfoUser> deleteProfileImage(Principal principal) {
+		return ResponseEntity.ok(userInfoService.deleteProfileImage(principal.getName()));
+	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
+++ b/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
 	AUCTION_NOT_FOUND(BAD_REQUEST, "해당 경매를 찾을 수 없습니다."),
 
 	USER_NOT_FOUND(BAD_REQUEST, "유저를 찾을 수 없습니다."),
+	USER_PROFILE_IMAGE_IS_EMPTY(BAD_REQUEST, "삭제할 프로필사진이 없습니다."),
 	THIS_PHONE_NUMBER_ALREADY_AUTHENTICATION(BAD_REQUEST, "이 번호는 이미 인증이 완료되었습니다."),
 	VERIFICATION_CODE_TIME_OUT(BAD_REQUEST, "인증번호 유효 시간이 만료됐습니다."),
 	WRONG_CODE_INPUT(BAD_REQUEST, "코드를 잘못 입력하셨습니다. 처음부터 다시 시도해주세요."),

--- a/a_uction/src/main/java/com/example/a_uction/model/user/dto/InfoUser.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/dto/InfoUser.java
@@ -11,13 +11,15 @@ import lombok.*;
 public class InfoUser {
 
 	private String username;
+	private String profileImageSrc;
 	private String userEmail;
 	private String phoneNumber;
 	private String description;
 
-	public InfoUser fromEntity(UserEntity userEntity){
+	public static InfoUser fromEntity(UserEntity userEntity){
 		return InfoUser.builder()
 				.userEmail(userEntity.getUserEmail())
+				.profileImageSrc(userEntity.getProfileImageSrc())
 				.phoneNumber(userEntity.getPhoneNumber())
 				.username(userEntity.getUsername())
 				.description(userEntity.getDescription())

--- a/a_uction/src/main/java/com/example/a_uction/model/user/dto/ModifyUser.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/dto/ModifyUser.java
@@ -28,7 +28,7 @@ public class ModifyUser {
 		private String phoneNumber;
 		private String description;
 
-		public ModifyUser.Response fromEntity(UserEntity userEntity){
+		public static ModifyUser.Response fromEntity(UserEntity userEntity){
 			return Response.builder()
 					.phoneNumber(userEntity.getPhoneNumber())
 					.username(userEntity.getUsername())

--- a/a_uction/src/main/java/com/example/a_uction/model/user/entity/UserEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/entity/UserEntity.java
@@ -42,6 +42,7 @@ public class UserEntity {
 	private String password;
 	private String username;
 	private String phoneNumber;
+	private String profileImageSrc;
 
 	@OneToMany(mappedBy = "user")
 	private List<AuctionEntity> auctions = new ArrayList<>();

--- a/a_uction/src/main/java/com/example/a_uction/service/user/KakaoService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/user/KakaoService.java
@@ -115,6 +115,7 @@ public class KakaoService {
 
 		userInfo.put("nickname", properties.get("nickname").toString());
 		userInfo.put("email", kakao_account.get("email").toString());
+		userInfo.put("profileImage", properties.get("profile_image").toString());
 
 		return userInfo;
 	}
@@ -127,6 +128,7 @@ public class KakaoService {
 			userRepository.save(UserEntity.builder()
 				.username(userInfo.get("nickname"))
 				.userEmail(email)
+				.profileImageSrc(userInfo.get("profileImage"))
 				.build());
 		}
 

--- a/a_uction/src/main/java/com/example/a_uction/service/user/UserInfoService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/user/UserInfoService.java
@@ -1,17 +1,20 @@
 package com.example.a_uction.service.user;
 
+import static com.example.a_uction.exception.constants.ErrorCode.ENTERED_THE_WRONG_PASSWORD;
+import static com.example.a_uction.exception.constants.ErrorCode.USER_NOT_FOUND;
+import static com.example.a_uction.exception.constants.ErrorCode.USER_PROFILE_IMAGE_IS_EMPTY;
+
 import com.example.a_uction.exception.AuctionException;
 import com.example.a_uction.model.user.dto.InfoUser;
 import com.example.a_uction.model.user.dto.ModifyUser;
 import com.example.a_uction.model.user.entity.UserEntity;
 import com.example.a_uction.model.user.repository.UserRepository;
+import com.example.a_uction.service.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import static com.example.a_uction.exception.constants.ErrorCode.ENTERED_THE_WRONG_PASSWORD;
-import static com.example.a_uction.exception.constants.ErrorCode.USER_NOT_FOUND;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +23,7 @@ public class UserInfoService {
 
 	private final UserRepository userRepository;
 	private final BCryptPasswordEncoder passwordEncoder;
+	private final S3Service s3Service;
 
 	public ModifyUser.Response modifyUserDetail(String userEmail, ModifyUser.Request updateRequest) {
 		UserEntity userEntity = userRepository.findByUserEmail(userEmail)
@@ -36,12 +40,42 @@ public class UserInfoService {
 
 		userEntity.updateUserEntity(updateRequest);
 
-		return new ModifyUser.Response().fromEntity(userRepository.save(userEntity));
+		return ModifyUser.Response.fromEntity(userRepository.save(userEntity));
 	}
 
 	public InfoUser userInfo(String userEmail){
 		UserEntity userEntity = userRepository.findByUserEmail(userEmail)
 				.orElseThrow(() -> new AuctionException(USER_NOT_FOUND));
-		return new InfoUser().fromEntity(userEntity);
+		return InfoUser.fromEntity(userEntity);
+	}
+
+	public InfoUser modifyProfileImage(MultipartFile file, String userEmail) {
+
+		UserEntity user = userRepository.getByUserEmail(userEmail);
+		String profileImageSrc = user.getProfileImageSrc();
+
+		if (profileImageSrc != null){
+			profileImageSrc = s3Service.getFileNameByUrl(profileImageSrc);
+			s3Service.delete(profileImageSrc);
+		}
+
+		user.setProfileImageSrc(s3Service.upload(file));
+
+		return InfoUser.fromEntity(userRepository.save(user));
+	}
+
+	public InfoUser deleteProfileImage(String userEmail) {
+		UserEntity user = userRepository.getByUserEmail(userEmail);
+		String profileImageSrc = user.getProfileImageSrc();
+
+		if (profileImageSrc == null){
+			throw new AuctionException(USER_PROFILE_IMAGE_IS_EMPTY);
+		}
+
+		profileImageSrc = s3Service.getFileNameByUrl(profileImageSrc);
+		s3Service.delete(profileImageSrc);
+		user.setProfileImageSrc(null);
+
+		return InfoUser.fromEntity(userRepository.save(user));
 	}
 }

--- a/a_uction/src/test/java/com/example/a_uction/controller/user/UserInfoControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/user/UserInfoControllerTest.java
@@ -1,11 +1,26 @@
 package com.example.a_uction.controller.user;
 
+import static com.example.a_uction.exception.constants.ErrorCode.ENTERED_THE_WRONG_PASSWORD;
+import static com.example.a_uction.exception.constants.ErrorCode.USER_NOT_FOUND;
+import static com.example.a_uction.exception.constants.ErrorCode.USER_PROFILE_IMAGE_IS_EMPTY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.example.a_uction.exception.AuctionException;
 import com.example.a_uction.model.user.dto.InfoUser;
 import com.example.a_uction.model.user.dto.ModifyUser;
 import com.example.a_uction.security.jwt.JwtProvider;
 import com.example.a_uction.service.user.UserInfoService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.FileInputStream;
+import java.io.IOException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,149 +29,224 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-
-import static com.example.a_uction.exception.constants.ErrorCode.ENTERED_THE_WRONG_PASSWORD;
-import static com.example.a_uction.exception.constants.ErrorCode.USER_NOT_FOUND;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserInfoController.class)
 class UserInfoControllerTest {
 
-    @MockBean
-    private UserInfoService userInfoService;
-    @MockBean
-    private JwtProvider jwtProvider;
-    @MockBean
-    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
-    @MockBean
-    private RedisTemplate<String, Object> redisTemplate;
-    @Autowired
-    private MockMvc mockMvc;
-    @Autowired
-    private ObjectMapper objectMapper;
+	@MockBean
+	private UserInfoService userInfoService;
+	@MockBean
+	private JwtProvider jwtProvider;
+	@MockBean
+	private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+	@MockBean
+	private RedisTemplate<String, Object> redisTemplate;
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
 
-    @Test
-    @WithMockUser
-    @DisplayName("회원정보 수정 - 성공")
-    void modifySuccess() throws Exception {
-        //given
-        ModifyUser.Request updateUser = ModifyUser.Request.builder()
-                .currentPassword("4321")
-                .phoneNumber("01043214321")
-                .updatePassword("")
-                .username("test1")
-                .description("나는야 경매왕")
-                .build();
+	private static final String TEST_IMAGE_SRC = "src/test/resources/image/test.png";
 
-        ModifyUser.Response response = ModifyUser.Response.builder()
-                .username("test1")
-                .phoneNumber("01043214321")
-                .description("나는야 경매왕")
-                .build();
+	@Test
+	@WithMockUser
+	@DisplayName("회원정보 수정 - 성공")
+	void modifySuccess() throws Exception {
+		//given
+		ModifyUser.Request updateUser = ModifyUser.Request.builder()
+			.currentPassword("4321")
+			.phoneNumber("01043214321")
+			.updatePassword("")
+			.username("test1")
+			.description("나는야 경매왕")
+			.build();
 
-        given(userInfoService.modifyUserDetail(any(), any())).willReturn(response);
+		ModifyUser.Response response = ModifyUser.Response.builder()
+			.username("test1")
+			.phoneNumber("01043214321")
+			.description("나는야 경매왕")
+			.build();
 
-        //when
-        //then
-        mockMvc.perform(put("/users/detail/modify").with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updateUser)))
-                .andExpect(jsonPath("$.username").value("test1"))
-                .andExpect(jsonPath("$.phoneNumber").value("01043214321"))
-                .andExpect(jsonPath("$.description").value("나는야 경매왕"))
-                .andExpect(status().isOk());
-    }
+		given(userInfoService.modifyUserDetail(any(), any())).willReturn(response);
 
-    @Test
-    @WithMockUser
-    @DisplayName("회원정보 수정 - 실패 - 사용자 없음")
-    void modifyFailUser() throws Exception {
-        //given
-        ModifyUser.Request updateUser = ModifyUser.Request.builder()
-                .currentPassword("4321")
-                .phoneNumber("01043214321")
-                .updatePassword("")
-                .username("test1")
-                .description("나는야 경매왕")
-                .build();
+		//when
+		//then
+		mockMvc.perform(put("/users/detail/modify").with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateUser)))
+			.andExpect(jsonPath("$.username").value("test1"))
+			.andExpect(jsonPath("$.phoneNumber").value("01043214321"))
+			.andExpect(jsonPath("$.description").value("나는야 경매왕"))
+			.andExpect(status().isOk());
+	}
 
-        given(userInfoService.modifyUserDetail(any(), any())).willThrow(new AuctionException(USER_NOT_FOUND));
+	@Test
+	@WithMockUser
+	@DisplayName("회원정보 수정 - 실패 - 사용자 없음")
+	void modifyFailUser() throws Exception {
+		//given
+		ModifyUser.Request updateUser = ModifyUser.Request.builder()
+			.currentPassword("4321")
+			.phoneNumber("01043214321")
+			.updatePassword("")
+			.username("test1")
+			.description("나는야 경매왕")
+			.build();
 
-        //when
-        //then
-        mockMvc.perform(put("/users/detail/modify").with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updateUser)))
-                .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"))
-                .andExpect(status().isOk());
-    }
+		given(userInfoService.modifyUserDetail(any(), any())).willThrow(
+			new AuctionException(USER_NOT_FOUND));
 
-
-    @Test
-    @WithMockUser
-    @DisplayName("회원정보 수정 - 실패 - 비밀번호 일치하지 않음")
-    void modifyFailPassword() throws Exception {
-        //given
-        ModifyUser.Request updateUser = ModifyUser.Request.builder()
-                .currentPassword("4321")
-                .phoneNumber("01043214321")
-                .updatePassword("")
-                .username("test1")
-                .description("나는야 경매왕")
-                .build();
+		//when
+		//then
+		mockMvc.perform(put("/users/detail/modify").with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateUser)))
+			.andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"))
+			.andExpect(status().isOk());
+	}
 
 
-        given(userInfoService.modifyUserDetail(any(), any())).willThrow(new AuctionException(ENTERED_THE_WRONG_PASSWORD));
+	@Test
+	@WithMockUser
+	@DisplayName("회원정보 수정 - 실패 - 비밀번호 일치하지 않음")
+	void modifyFailPassword() throws Exception {
+		//given
+		ModifyUser.Request updateUser = ModifyUser.Request.builder()
+			.currentPassword("4321")
+			.phoneNumber("01043214321")
+			.updatePassword("")
+			.username("test1")
+			.description("나는야 경매왕")
+			.build();
 
-        //when
-        //then
-        mockMvc.perform(put("/users/detail/modify").with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updateUser)))
-                .andExpect(jsonPath("$.errorCode").value("ENTERED_THE_WRONG_PASSWORD"))
-                .andExpect(status().isOk());
-    }
+		given(userInfoService.modifyUserDetail(any(), any())).willThrow(
+			new AuctionException(ENTERED_THE_WRONG_PASSWORD));
 
-    @Test
-    @WithMockUser
-    @DisplayName("회원정보 보기 - 성공")
-    void userInfoSuccess() throws Exception {
-        //given
-        InfoUser infoUser = InfoUser.builder()
-                .username("test")
-                .userEmail("test@test.com")
-                .phoneNumber("01012345678")
-                .description("나는야 경매왕")
-                .build();
+		//when
+		//then
+		mockMvc.perform(put("/users/detail/modify").with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateUser)))
+			.andExpect(jsonPath("$.errorCode").value("ENTERED_THE_WRONG_PASSWORD"))
+			.andExpect(status().isOk());
+	}
 
-        given(userInfoService.userInfo(any())).willReturn(infoUser);
-        //when
-        //then
-        mockMvc.perform(get("/users/detail").with(csrf()))
-                .andExpect(jsonPath("$.username").value("test"))
-                .andExpect(jsonPath("$.userEmail").value("test@test.com"))
-                .andExpect(jsonPath("$.phoneNumber").value("01012345678"))
-                .andExpect(jsonPath("$.description").value("나는야 경매왕"))
-                .andExpect(status().isOk());
-    }
+	@Test
+	@WithMockUser
+	@DisplayName("회원정보 보기 - 성공")
+	void userInfoSuccess() throws Exception {
+		//given
+		InfoUser infoUser = InfoUser.builder()
+			.username("test")
+			.userEmail("test@test.com")
+			.phoneNumber("01012345678")
+			.description("나는야 경매왕")
+			.build();
 
-    @Test
-    @WithMockUser
-    @DisplayName("회원정보 보기 - 실패")
-    void userInfoFail() throws Exception {
-        //given
-        given(userInfoService.userInfo(any())).willThrow(new AuctionException(USER_NOT_FOUND));
-        //when
-        //then
-        mockMvc.perform(get("/users/detail").with(csrf()))
-                .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"))
-                .andExpect(status().isOk());
-    }
+		given(userInfoService.userInfo(any())).willReturn(infoUser);
+		//when
+		//then
+		mockMvc.perform(get("/users/detail").with(csrf()))
+			.andExpect(jsonPath("$.username").value("test"))
+			.andExpect(jsonPath("$.userEmail").value("test@test.com"))
+			.andExpect(jsonPath("$.phoneNumber").value("01012345678"))
+			.andExpect(jsonPath("$.description").value("나는야 경매왕"))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@WithMockUser
+	@DisplayName("회원정보 보기 - 실패")
+	void userInfoFail() throws Exception {
+		//given
+		given(userInfoService.userInfo(any())).willThrow(new AuctionException(USER_NOT_FOUND));
+		//when
+		//then
+		mockMvc.perform(get("/users/detail").with(csrf()))
+			.andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@WithMockUser
+	@DisplayName("프로필이미지추가")
+	void user_modifyProfileImage() throws Exception {
+		//given
+		given(userInfoService.modifyProfileImage(any(), any()))
+			.willReturn(InfoUser.builder()
+			.username("test")
+			.profileImageSrc("~/test/docker.png")
+			.userEmail("test@test.com")
+			.phoneNumber("01012345678")
+			.description("나는야 경매왕")
+			.build());
+		//when
+		MockMultipartFile image = this.getMockMultipartFile("file", "image/png", TEST_IMAGE_SRC);
+
+		//then
+		mockMvc.perform(multipart("/users/detail/modify/profile-image")
+				.file(image)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(csrf()))
+			.andDo(print())
+			.andExpect(jsonPath("$.username").value("test"))
+			.andExpect(jsonPath("$.profileImageSrc").value("~/test/docker.png"))
+			.andExpect(jsonPath("$.userEmail").value("test@test.com"))
+			.andExpect(jsonPath("$.phoneNumber").value("01012345678"))
+			.andExpect(jsonPath("$.description").value("나는야 경매왕"))
+			.andExpect(status().isOk());
+	}
+	@Test
+	@WithMockUser
+	@DisplayName("프로필이미지삭제")
+	void user_deleteProfileImage() throws Exception {
+		//given
+		InfoUser infoUser = InfoUser.builder()
+			.username("test")
+			.profileImageSrc(null)
+			.userEmail("test@test.com")
+			.phoneNumber("01012345678")
+			.description("나는야 경매왕")
+			.build();
+
+		given(userInfoService.deleteProfileImage(any()))
+			.willReturn(infoUser);
+		//when
+
+		//then
+		mockMvc.perform(put("/users/detail/delete/profile-image")
+				.with(csrf()))
+			.andDo(print())
+			.andExpect(jsonPath("$.username").value("test"))
+			.andExpect(jsonPath("$.userEmail").value("test@test.com"))
+			.andExpect(jsonPath("$.phoneNumber").value("01012345678"))
+			.andExpect(jsonPath("$.description").value("나는야 경매왕"))
+			.andExpect(jsonPath("$.profileImageSrc").isEmpty())
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@WithMockUser
+	@DisplayName("프로필사진 삭제 실패")
+	void deleteUserProfileImage_fail() throws Exception {
+		//given
+		given(userInfoService.deleteProfileImage(any()))
+			.willThrow(new AuctionException(USER_PROFILE_IMAGE_IS_EMPTY));
+		//when
+		//then
+		mockMvc.perform(put("/users/detail/delete/profile-image")
+				.with(csrf()))
+			.andExpect(jsonPath("$.errorCode")
+				.value("USER_PROFILE_IMAGE_IS_EMPTY"))
+			.andExpect(status().isOk());
+	}
+	private MockMultipartFile getMockMultipartFile(String fileName, String contentType, String path)
+		throws IOException {
+		FileInputStream fileInputStream = new FileInputStream(path);
+		return new MockMultipartFile(fileName, fileName + "." + contentType, contentType,
+			fileInputStream);
+	}
 }

--- a/a_uction/src/test/java/com/example/a_uction/service/user/UserInfoServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/user/UserInfoServiceTest.java
@@ -1,16 +1,22 @@
 package com.example.a_uction.service.user;
 
 import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.model.user.dto.InfoUser;
 import com.example.a_uction.model.user.dto.ModifyUser;
 import com.example.a_uction.model.user.entity.UserEntity;
 import com.example.a_uction.model.user.repository.UserRepository;
+import com.example.a_uction.service.s3.S3Service;
+import java.io.FileInputStream;
+import java.io.IOException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.time.LocalDateTime;
@@ -18,10 +24,14 @@ import java.util.Optional;
 
 import static com.example.a_uction.exception.constants.ErrorCode.ENTERED_THE_WRONG_PASSWORD;
 import static com.example.a_uction.exception.constants.ErrorCode.USER_NOT_FOUND;
+import static com.example.a_uction.exception.constants.ErrorCode.USER_PROFILE_IMAGE_IS_EMPTY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class UserInfoServiceTest {
@@ -29,12 +39,16 @@ class UserInfoServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private S3Service s3Service;
+
     @InjectMocks
     private UserInfoService userInfoService;
 
     @Spy
     private BCryptPasswordEncoder passwordEncoder;
 
+    private static final String TEST_IMAGE_SRC = "src/test/resources/image/test.png";
 
     @Test
     @DisplayName("회원정보 수정 - 성공")
@@ -161,5 +175,106 @@ class UserInfoServiceTest {
 
         //then
         assertEquals(USER_NOT_FOUND, exception.getErrorCode());
+    }
+    @Test
+    @DisplayName("프로필이미지 등록")
+    void addProfileImage() throws IOException {
+        //given
+        UserEntity user = UserEntity
+            .builder()
+            .userEmail("test@test.com")
+            .profileImageSrc(null)
+            .build();
+        given(userRepository.getByUserEmail(anyString()))
+            .willReturn(user);
+        given(s3Service.upload(any()))
+            .willReturn("~/test/test.png");
+        given(userRepository.save(any()))
+            .willReturn(user);
+
+        //when
+        MockMultipartFile image = this.getMockMultipartFile("file", "image/png", TEST_IMAGE_SRC);
+        InfoUser infoUser = userInfoService.modifyProfileImage(image, user.getUserEmail());
+
+        //then
+        assertEquals(infoUser.getProfileImageSrc(), "~/test/test.png");
+    }
+    @Test
+    @DisplayName("프로필이미지 수정")
+    void modifyProfileImage() throws IOException {
+        //given
+        UserEntity user = UserEntity
+            .builder()
+            .userEmail("test@test.com")
+            .profileImageSrc("~/test/test.png")
+            .build();
+        given(userRepository.getByUserEmail(anyString()))
+            .willReturn(user);
+        given(s3Service.upload(any()))
+            .willReturn("~/test/docker.png");
+        given(userRepository.save(any()))
+            .willReturn(user);
+
+        //when
+        MockMultipartFile image = this.getMockMultipartFile("file", "image/png", TEST_IMAGE_SRC);
+        InfoUser infoUser = userInfoService.modifyProfileImage(image, user.getUserEmail());
+
+        //then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(s3Service).getFileNameByUrl(captor.capture());
+        assertEquals(captor.getValue(), "~/test/test.png");
+        assertEquals(infoUser.getProfileImageSrc(), "~/test/docker.png");
+    }
+    @Test
+    @DisplayName("프로필사진 삭제-성공")
+    void deleteProfileImage_success () {
+        //given
+        UserEntity user = UserEntity
+            .builder()
+            .userEmail("test@test.com")
+            .profileImageSrc("~test/test.png")
+            .build();
+
+        given(userRepository.getByUserEmail(anyString()))
+            .willReturn(user);
+        given(userRepository.save(any()))
+            .willReturn(user);
+
+        //when
+        InfoUser infoUser = userInfoService.deleteProfileImage("test@test.com");
+
+        //then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(s3Service).getFileNameByUrl(captor.capture());
+        assertEquals(captor.getValue(), "~test/test.png");
+        assertNull(infoUser.getProfileImageSrc());
+    }
+    @Test
+    @DisplayName("프로필사진 삭제-실패")
+    void deleteProfileImage_fail () {
+        //given
+        UserEntity user = UserEntity
+            .builder()
+            .userEmail("test@test.com")
+            .profileImageSrc(null)
+            .build();
+
+        given(userRepository.getByUserEmail(anyString()))
+            .willReturn(user);
+
+        //when
+        AuctionException exception =
+            assertThrows(AuctionException.class,
+                () -> userInfoService.deleteProfileImage("test@test.com"));
+
+        //then
+        assertEquals(USER_PROFILE_IMAGE_IS_EMPTY, exception.getErrorCode());
+    }
+
+    private MockMultipartFile getMockMultipartFile(String fileName, String contentType, String path)
+        throws IOException {
+        FileInputStream fileInputStream = new FileInputStream(path);
+        return new MockMultipartFile(fileName, fileName + "." + contentType, contentType,
+            fileInputStream);
     }
 }

--- a/auction-user-api.http
+++ b/auction-user-api.http
@@ -72,3 +72,19 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZUBnbWFpb
  "from" : "카카오",
  "money" : 100000
 }
+
+### 프로필 사진 등록
+POST http://localhost:8081/users/detail/modify/profile-image
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZUBnbWFpbC5jb20iLCJzdWIiOiJBY2Nlc3NUb2tlbiIsImlhdCI6MTY4MjIzODUxNSwiZXhwIjoxNjgyMjQyMTE1fQ.__ner9x3-EAts-FwHIFl9cjOBYta7LiBIuTtX39Nr1U
+Content-Type: multipart/form-data; boundary=--------------------------1234567890
+
+----------------------------1234567890
+Content-Disposition: form-data; name="file"; filename="dockerImage.png"
+Content-Type: image/png
+
+< a_uction/src/test/resources/image/dockerImage.png
+----------------------------1234567890--
+
+### 프로필 사진 삭제
+PUT http://localhost:8081/users/detail/delete/profile-image
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZUBnbWFpbC5jb20iLCJzdWIiOiJBY2Nlc3NUb2tlbiIsImlhdCI6MTY4MjIzODUxNSwiZXhwIjoxNjgyMjQyMTE1fQ.__ner9x3-EAts-FwHIFl9cjOBYta7LiBIuTtX39Nr1U


### PR DESCRIPTION
Changes
---

userEntity 필드에 profileImageSource 추가
프로필이미지를 등록 하는 endpoint 생성
프로필이미지를 삭제 하는 endpoint 생성
s3 업로드, 삭제 가능
관련 테스트코드 작성완료

Background
---

프로필사진이 이미 있으면 기존에 이미지를 삭제하고 다시 저장합니다
프로필사진이 없는데 삭제하려고하면 에러가납니다


closes #102 