### PR TITLE
feat & refactor : [feat/#105/auction-transaction-history-image]

### DIFF
--- a/a_uction/src/main/java/com/example/a_uction/model/auction/dto/AuctionDto.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/dto/AuctionDto.java
@@ -87,7 +87,7 @@ public class AuctionDto {
 		private LocalDateTime startDateTime;
 		private LocalDateTime endDateTime;
 		private String description;
-		private List<String> files;
+		private List<String> imagesSrc;
         private Long buyerId;
 
 
@@ -106,7 +106,7 @@ public class AuctionDto {
 				.startDateTime(auctionEntity.getStartDateTime())
 				.endDateTime(auctionEntity.getEndDateTime())
 				.description(auctionEntity.getDescription())
-				.files(auctionEntity.getFilesSrc())
+				.imagesSrc(auctionEntity.getImagesSrc())
 				.build();
 		}
 

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionEntity.java
@@ -66,7 +66,7 @@ public class AuctionEntity {
     @ElementCollection
     @Builder.Default
     @OrderColumn
-    private List<String> filesSrc = new ArrayList<>();
+    private List<String> imagesSrc = new ArrayList<>();
 
     public void updateEntity(AuctionDto.Request updateAuction) {
         this.setItemName(updateAuction.getItemName());

--- a/a_uction/src/main/java/com/example/a_uction/model/auctionTransactionHistory/dto/AuctionTransactionHistoryDto.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auctionTransactionHistory/dto/AuctionTransactionHistoryDto.java
@@ -5,22 +5,24 @@ import lombok.Builder;
 
 public class AuctionTransactionHistoryDto {
 
-    @Builder
-    static class Response{
-        private String sellerEmail;
-        private String itemName;
-        private int price;
-        private String buyerEmail;
-        private String imageSrc;
+	@Builder
+	static class Response {
 
-        public AuctionTransactionHistoryDto.Response fromEntity(AuctionTransactionHistoryEntity auctionTransactionHistory){
-            return Response.builder()
-                    .sellerEmail(auctionTransactionHistory.getSellerEmail())
-                    .buyerEmail(auctionTransactionHistory.getBuyerEmail())
-                    .itemName(auctionTransactionHistory.getItemName())
-                    .price(auctionTransactionHistory.getPrice())
-                    .imageSrc(auctionTransactionHistory.getImageSrc())
-                    .build();
-        }
-    }
+		private String sellerEmail;
+		private String itemName;
+		private int price;
+		private String buyerEmail;
+		private String imageSrc;
+
+		public static AuctionTransactionHistoryDto.Response fromEntity(
+			AuctionTransactionHistoryEntity auctionTransactionHistory) {
+			return Response.builder()
+				.sellerEmail(auctionTransactionHistory.getSellerEmail())
+				.buyerEmail(auctionTransactionHistory.getBuyerEmail())
+				.itemName(auctionTransactionHistory.getItemName())
+				.price(auctionTransactionHistory.getPrice())
+				.imageSrc(auctionTransactionHistory.getImageSrc())
+				.build();
+		}
+	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/model/auctionTransactionHistory/entity/AuctionTransactionHistoryEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auctionTransactionHistory/entity/AuctionTransactionHistoryEntity.java
@@ -1,5 +1,7 @@
 package com.example.a_uction.model.auctionTransactionHistory.entity;
 
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,12 +11,17 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
+@Setter
 @Builder
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class AuctionTransactionHistoryEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,5 +36,8 @@ public class AuctionTransactionHistoryEntity {
     private String buyerEmail;
 
     private String imageSrc;
+
+    @CreatedDate
+    private LocalDateTime createDateTime;
 
 }

--- a/a_uction/src/main/java/com/example/a_uction/service/auction/AuctionFileService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/auction/AuctionFileService.java
@@ -18,7 +18,7 @@ public class AuctionFileService {
 
 	public AuctionEntity addFiles(List<MultipartFile> files, AuctionEntity auction) {
 		if (files != null) {
-			auction.setFilesSrc(s3Service.uploadFiles(files));
+			auction.setImagesSrc(s3Service.uploadFiles(files));
 			return auctionRepository.save(auction);
 		}
 		return auction;
@@ -27,7 +27,7 @@ public class AuctionFileService {
 	@Transactional
 	public AuctionEntity addImage(MultipartFile file, AuctionEntity auction) {
 		// 원래 매핑되어있던 파일 db, s3 삭제
-		auction.getFilesSrc().add(s3Service.upload(file));
+		auction.getImagesSrc().add(s3Service.upload(file));
 
 		return auctionRepository.save(auction);
 	}
@@ -37,7 +37,7 @@ public class AuctionFileService {
 		// 원래 매핑되어있던 파일 db, s3 삭제
 		s3Service.delete(s3Service.getFileNameByUrl(fileUrl));
 
-		auction.getFilesSrc().remove(fileUrl);
+		auction.getImagesSrc().remove(fileUrl);
 
 		return auctionRepository.save(auction);
 	}
@@ -48,7 +48,7 @@ public class AuctionFileService {
 
 	private List<String> getFileNamesByAuctionId(Long auctionId) {
 		return auctionRepository.getByAuctionId(auctionId)
-			.getFilesSrc();
+			.getImagesSrc();
 	}
 
 

--- a/a_uction/src/test/java/com/example/a_uction/controller/auction/AuctionControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/auction/AuctionControllerTest.java
@@ -147,7 +147,7 @@ class AuctionControllerTest {
 			.itemStatus(ItemStatus.GOOD)
 			.startDateTime(startTime)
 			.endDateTime(endTime)
-			.filesSrc(files)
+			.imagesSrc(files)
 			.build();
 
 		given(auctionService.updateAuction(any(AuctionDto.Request.class), any(), any(), anyLong()))

--- a/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionFileServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionFileServiceTest.java
@@ -44,7 +44,7 @@ class AuctionFileServiceTest {
 
 		AuctionEntity auction = AuctionEntity.builder()
             .itemName("test item")
-            .filesSrc(new ArrayList<>())
+            .imagesSrc(new ArrayList<>())
             .build();
 
         List<MultipartFile> mockFiles = getFiles();
@@ -52,7 +52,7 @@ class AuctionFileServiceTest {
         given(s3Service.uploadFiles(any()))
             .willReturn(files);
 
-        auction.setFilesSrc(files);
+        auction.setImagesSrc(files);
         given(auctionRepository.save(any()))
             .willReturn(auction);
 
@@ -60,9 +60,9 @@ class AuctionFileServiceTest {
         AuctionEntity result = auctionFileService.addFiles(mockFiles, auction);
 
         //then
-        assertEquals(result.getFilesSrc().size(), 2);
-        assertEquals(result.getFilesSrc().get(0), "~/test/image.png");
-        assertEquals(result.getFilesSrc().get(1), "~/test/docker.png");
+        assertEquals(result.getImagesSrc().size(), 2);
+        assertEquals(result.getImagesSrc().get(0), "~/test/image.png");
+        assertEquals(result.getImagesSrc().get(1), "~/test/docker.png");
     }
 
     @Test
@@ -71,13 +71,13 @@ class AuctionFileServiceTest {
         //given
         AuctionEntity auction = AuctionEntity.builder()
             .itemName("test item")
-            .filesSrc(new ArrayList<>())
+            .imagesSrc(new ArrayList<>())
             .build();
 
         MultipartFile file = this.getMockMultipartFile("test", "image/png",
             "src/test/resources/image/test.png");
 
-        auction.getFilesSrc().add("~/test/image.png");
+        auction.getImagesSrc().add("~/test/image.png");
 
         given(s3Service.upload(any()))
             .willReturn("~/test/docker.png");
@@ -89,9 +89,9 @@ class AuctionFileServiceTest {
         AuctionEntity auctionEntity = auctionFileService.addImage(file, auction);
 
         //then
-        assertEquals(auctionEntity.getFilesSrc().size(), 2);
-        assertEquals(auctionEntity.getFilesSrc().get(0), "~/test/image.png");
-        assertEquals(auctionEntity.getFilesSrc().get(1), "~/test/docker.png");
+        assertEquals(auctionEntity.getImagesSrc().size(), 2);
+        assertEquals(auctionEntity.getImagesSrc().get(0), "~/test/image.png");
+        assertEquals(auctionEntity.getImagesSrc().get(1), "~/test/docker.png");
     }
 
     @Test
@@ -99,16 +99,16 @@ class AuctionFileServiceTest {
         //given
         AuctionEntity auction = AuctionEntity.builder()
             .itemName("test item")
-            .filesSrc(new ArrayList<>())
+            .imagesSrc(new ArrayList<>())
             .build();
-        auction.getFilesSrc().add("~/test/docker.png");
-        auction.getFilesSrc().add("~/test/image.png");
+        auction.getImagesSrc().add("~/test/docker.png");
+        auction.getImagesSrc().add("~/test/image.png");
         String fileUrl = "~/test/docker.png";
 
         given(auctionRepository.save(any()))
             .willReturn(AuctionEntity.builder()
                 .itemName("test item")
-                .filesSrc(
+                .imagesSrc(
                     List.of("~/test/docker.png", "~/test/image.png"))
                 .build()
             );
@@ -119,11 +119,11 @@ class AuctionFileServiceTest {
         ArgumentCaptor<AuctionEntity> captor = ArgumentCaptor.forClass(AuctionEntity.class);
         verify(auctionRepository, times(1)).save(captor.capture());
 
-        assertEquals(captor.getValue().getFilesSrc().size(), 1);
-        assertEquals(captor.getValue().getFilesSrc().get(0), "~/test/image.png");
-        assertEquals(auctionEntity.getFilesSrc().size(), 2);
-        assertEquals(auctionEntity.getFilesSrc().get(0), "~/test/docker.png");
-        assertEquals(auctionEntity.getFilesSrc().get(1), "~/test/image.png");
+        assertEquals(captor.getValue().getImagesSrc().size(), 1);
+        assertEquals(captor.getValue().getImagesSrc().get(0), "~/test/image.png");
+        assertEquals(auctionEntity.getImagesSrc().size(), 2);
+        assertEquals(auctionEntity.getImagesSrc().get(0), "~/test/docker.png");
+        assertEquals(auctionEntity.getImagesSrc().get(1), "~/test/image.png");
     }
 
     private List<MultipartFile> getFiles() throws IOException {

--- a/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionServiceTest.java
@@ -86,7 +86,7 @@ class AuctionServiceTest {
 			.minimumBid(200)
 			.startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
 			.endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
-			.filesSrc(files)
+			.imagesSrc(files)
 			.build();
 
 		given(auctionRepository.save(any()))
@@ -119,7 +119,7 @@ class AuctionServiceTest {
 		assertEquals(200, response.getMinimumBid());
 		assertEquals(LocalDateTime.parse("2025-04-15T17:09:42.411"), response.getStartDateTime());
 		assertEquals(LocalDateTime.parse("2025-04-15T17:10:42.411"), response.getEndDateTime());
-		assertEquals("~/test/image.png", response.getFiles().get(0));
+		assertEquals("~/test/image.png", response.getImagesSrc().get(0));
 	}
 
 	@Test
@@ -175,7 +175,7 @@ class AuctionServiceTest {
 				.minimumBid(200)
 				.startDateTime(LocalDateTime.parse("2023-04-15T17:09:42.411"))
 				.endDateTime(LocalDateTime.parse("2023-04-15T17:10:42.411"))
-				.filesSrc(files)
+				.imagesSrc(files)
 				.build()));
 		//when
 		AuctionDto.Response response = auctionService.getAuctionByAuctionId(1L);
@@ -232,7 +232,7 @@ class AuctionServiceTest {
 			.itemStatus(ItemStatus.BAD)
 			.startDateTime(LocalDateTime.of(2026, 5, 1, 0, 0, 0))
 			.endDateTime(LocalDateTime.of(2026, 5, 2, 0, 0, 0))
-			.filesSrc(files)
+			.imagesSrc(files)
 			.build();
 
 		given(auctionRepository.findByUserIdAndAuctionId(any(), anyLong()))
@@ -253,7 +253,7 @@ class AuctionServiceTest {
 		assertEquals(endTime, result.getEndDateTime());
 		assertEquals(2000, result.getMinimumBid());
 		assertEquals(1000, result.getStartingPrice());
-		assertEquals("~/test/image.png", result.getFiles().get(0));
+		assertEquals("~/test/image.png", result.getImagesSrc().get(0));
 	}
 
 	@Test
@@ -357,7 +357,7 @@ class AuctionServiceTest {
 				.itemStatus(ItemStatus.BAD)
 				.startDateTime(LocalDateTime.of(2025, 4, 1, 0, 0, 0))
 				.endDateTime(LocalDateTime.of(2025, 4, 10, 0, 0, 0))
-				.filesSrc(files)
+				.imagesSrc(files)
 				.build(),
 			AuctionEntity.builder()
 				.auctionId(2L)
@@ -369,7 +369,7 @@ class AuctionServiceTest {
 				.itemStatus(ItemStatus.GOOD)
 				.startDateTime(LocalDateTime.of(2023, 4, 11, 0, 0, 0))
 				.endDateTime(LocalDateTime.of(2023, 4, 20, 0, 0, 0))
-				.filesSrc(files)
+				.imagesSrc(files)
 				.build()
 
 		);
@@ -390,12 +390,12 @@ class AuctionServiceTest {
 		assertEquals(1111, result.toList().get(0).getStartingPrice());
 		assertEquals(1000, result.toList().get(0).getMinimumBid());
 		assertEquals(ItemStatus.BAD, result.toList().get(0).getItemStatus());
-		assertEquals("~/test/image.png", result.toList().get(0).getFiles().get(0));
+		assertEquals("~/test/image.png", result.toList().get(0).getImagesSrc().get(0));
 		assertEquals("item2", result.toList().get(1).getItemName());
 		assertEquals(2222, result.toList().get(1).getStartingPrice());
 		assertEquals(2000, result.toList().get(1).getMinimumBid());
 		assertEquals(ItemStatus.GOOD, result.toList().get(1).getItemStatus());
-		assertEquals("~/test/image.png", result.toList().get(1).getFiles().get(0));
+		assertEquals("~/test/image.png", result.toList().get(1).getImagesSrc().get(0));
 	}
 
 	@Test
@@ -434,7 +434,7 @@ class AuctionServiceTest {
 			.itemStatus(ItemStatus.BAD)
 			.startDateTime(LocalDateTime.of(2025, 4, 12, 0, 0, 0))
 			.endDateTime(LocalDateTime.of(2025, 4, 13, 0, 0, 0))
-			.filesSrc(files)
+			.imagesSrc(files)
 			.build();
 		given(auctionRepository.findByUserIdAndAuctionId(any(), anyLong()))
 			.willReturn(Optional.of(auction));
@@ -450,7 +450,7 @@ class AuctionServiceTest {
 		assertEquals(TransactionStatus.TRANSACTION_COMPLETE,
 			captor.getValue().getTransactionStatus());
 		assertEquals(1000, captor.getValue().getMinimumBid());
-		assertEquals("~/test/image.png", captor.getValue().getFilesSrc().get(0));
+		assertEquals("~/test/image.png", captor.getValue().getImagesSrc().get(0));
 	}
 
 	@Test
@@ -515,7 +515,7 @@ class AuctionServiceTest {
 				.itemStatus(ItemStatus.BAD)
 				.startDateTime(LocalDateTime.of(2022, 4, 1, 0, 0, 0))
 				.endDateTime(LocalDateTime.of(2025, 4, 10, 0, 0, 0))
-				.filesSrc(files)
+				.imagesSrc(files)
 				.build(),
 			AuctionEntity.builder()
 				.auctionId(2L)
@@ -526,7 +526,7 @@ class AuctionServiceTest {
 				.itemStatus(ItemStatus.GOOD)
 				.startDateTime(LocalDateTime.of(2022, 4, 11, 0, 0, 0))
 				.endDateTime(LocalDateTime.of(2023, 4, 20, 0, 0, 0))
-				.filesSrc(files)
+				.imagesSrc(files)
 				.build()
 		);
 		Page<AuctionEntity> page = new PageImpl<>(list);
@@ -542,12 +542,12 @@ class AuctionServiceTest {
 		assertEquals(1111, result.toList().get(0).getStartingPrice());
 		assertEquals(1000, result.toList().get(0).getMinimumBid());
 		assertEquals(ItemStatus.BAD, result.toList().get(0).getItemStatus());
-		assertEquals("~/test/image.png", result.toList().get(0).getFiles().get(0));
+		assertEquals("~/test/image.png", result.toList().get(0).getImagesSrc().get(0));
 		assertEquals("item2", result.toList().get(1).getItemName());
 		assertEquals(2222, result.toList().get(1).getStartingPrice());
 		assertEquals(2000, result.toList().get(1).getMinimumBid());
 		assertEquals(ItemStatus.GOOD, result.toList().get(1).getItemStatus());
-		assertEquals("~/test/image.png", result.toList().get(1).getFiles().get(0));
+		assertEquals("~/test/image.png", result.toList().get(1).getImagesSrc().get(0));
 	}
 
 	@Test
@@ -566,7 +566,7 @@ class AuctionServiceTest {
 				.itemStatus(ItemStatus.BAD)
 				.startDateTime(LocalDateTime.of(2024, 4, 1, 0, 0, 0))
 				.endDateTime(LocalDateTime.of(2025, 4, 10, 0, 0, 0))
-				.filesSrc(files)
+				.imagesSrc(files)
 				.build(),
 			AuctionEntity.builder()
 				.auctionId(2L)
@@ -577,7 +577,7 @@ class AuctionServiceTest {
 				.itemStatus(ItemStatus.GOOD)
 				.startDateTime(LocalDateTime.of(2024, 4, 11, 0, 0, 0))
 				.endDateTime(LocalDateTime.of(2025, 4, 20, 0, 0, 0))
-				.filesSrc(files)
+				.imagesSrc(files)
 				.build()
 		);
 		Page<AuctionEntity> page = new PageImpl<>(list);
@@ -592,12 +592,12 @@ class AuctionServiceTest {
 		assertEquals(1111, result.toList().get(0).getStartingPrice());
 		assertEquals(1000, result.toList().get(0).getMinimumBid());
 		assertEquals(ItemStatus.BAD, result.toList().get(0).getItemStatus());
-		assertEquals("~/test/image.png", result.toList().get(0).getFiles().get(0));
+		assertEquals("~/test/image.png", result.toList().get(0).getImagesSrc().get(0));
 		assertEquals("item2", result.toList().get(1).getItemName());
 		assertEquals(2222, result.toList().get(1).getStartingPrice());
 		assertEquals(2000, result.toList().get(1).getMinimumBid());
 		assertEquals(ItemStatus.GOOD, result.toList().get(1).getItemStatus());
-		assertEquals("~/test/image.png", result.toList().get(1).getFiles().get(0));
+		assertEquals("~/test/image.png", result.toList().get(1).getImagesSrc().get(0));
 	}
 
 	@Test
@@ -617,7 +617,7 @@ class AuctionServiceTest {
 				.itemStatus(ItemStatus.BAD)
 				.startDateTime(LocalDateTime.of(2021, 4, 1, 0, 0, 0))
 				.endDateTime(LocalDateTime.of(2022, 4, 10, 0, 0, 0))
-				.filesSrc(files)
+				.imagesSrc(files)
 				.build(),
 			AuctionEntity.builder()
 				.auctionId(2L)
@@ -629,7 +629,7 @@ class AuctionServiceTest {
 				.itemStatus(ItemStatus.GOOD)
 				.startDateTime(LocalDateTime.of(2021, 4, 11, 0, 0, 0))
 				.endDateTime(LocalDateTime.of(2022, 4, 20, 0, 0, 0))
-				.filesSrc(files)
+				.imagesSrc(files)
 				.build()
 		);
 		Page<AuctionEntity> page = new PageImpl<>(list);
@@ -646,14 +646,14 @@ class AuctionServiceTest {
 		assertEquals(TransactionStatus.TRANSACTION_COMPLETE,
 			result.toList().get(0).getTransactionStatus());
 		assertEquals(ItemStatus.BAD, result.toList().get(0).getItemStatus());
-		assertEquals("~/test/image.png", result.toList().get(0).getFiles().get(0));
+		assertEquals("~/test/image.png", result.toList().get(0).getImagesSrc().get(0));
 		assertEquals("item2", result.toList().get(1).getItemName());
 		assertEquals(2222, result.toList().get(1).getStartingPrice());
 		assertEquals(2000, result.toList().get(1).getMinimumBid());
 		assertEquals(TransactionStatus.TRANSACTION_COMPLETE,
 			result.toList().get(1).getTransactionStatus());
 		assertEquals(ItemStatus.GOOD, result.toList().get(1).getItemStatus());
-		assertEquals("~/test/image.png", result.toList().get(1).getFiles().get(0));
+		assertEquals("~/test/image.png", result.toList().get(1).getImagesSrc().get(0));
 	}
 
 	@Test
@@ -701,10 +701,14 @@ class AuctionServiceTest {
 	@Test
 	@DisplayName("경매 종료 - 경매 성공")
 	void auctionFinishedComplete() {
+		List<String> imageSrc = new ArrayList<>();
+		imageSrc.add("~/test/test.png");
+
 		LocalDateTime now = LocalDateTime.now();
 		AuctionEntity auction = AuctionEntity.builder()
 			.auctionId(1L)
 			.user(UserEntity.builder().id(1L).build())
+			.imagesSrc(imageSrc)
 			.itemName("item1")
 			.startingPrice(1111)
 			.minimumBid(1000)
@@ -727,6 +731,7 @@ class AuctionServiceTest {
 			.price(biddingHistory.getPrice())
 			.itemName(auction.getItemName())
 			.buyerEmail(user.getUserEmail())
+			.imageSrc(auction.getImagesSrc().get(0))
 			.sellerEmail(auction.getUser().getUserEmail())
 			.build();
 
@@ -741,6 +746,7 @@ class AuctionServiceTest {
 
 		assertEquals(response.getTransactionStatus(), TransactionStatus.TRANSACTION_COMPLETE);
 		assertEquals(response.getBuyerId(), user.getId());
+		assertEquals(response.getImagesSrc().get(0), "~/test/test.png");
 	}
 
 	@Test


### PR DESCRIPTION
Changes
---

경매 결과를 저장하는 테이블 컬럼에 image 추가
auctionEntity 필드 중 filesSrc 를 imagesSrc 로 변경
auction-transaction-history-entity 필드로 createDateTime 추가
testCode 변경 완료

Background
---

경매 완료 후 경매 결과가 저장 될때
해당 경매의 이미지가 없으면 그냥 저장
이미지가 있으면 대표이미지로 경매의 첫번째 이미지를 저장하고 확인할 수 있다.


closes #105 