### PR TITLE
Refactor : [Refactor/#110/elasticSearch/0] elastic search - item name sort 기준 변경

### DIFF
--- a/a_uction/src/main/java/com/example/a_uction/config/ElasticSearchConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/config/ElasticSearchConfig.java
@@ -1,6 +1,7 @@
 package com.example.a_uction.config;
 
 import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.RestClients;
@@ -12,10 +13,13 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 @EnableElasticsearchRepositories
 public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
 
+    @Value("${es.host}")
+    private String host;
+
     @Override
     public RestHighLevelClient elasticsearchClient() {
         ClientConfiguration clientConfiguration = ClientConfiguration.builder()
-                .connectedTo("3.35.38.11:9200")
+                .connectedTo(host)
                 .build();
         return RestClients.create(clientConfiguration).rest();
     }

--- a/a_uction/src/main/java/com/example/a_uction/config/ElasticSearchConfig.java
+++ b/a_uction/src/main/java/com/example/a_uction/config/ElasticSearchConfig.java
@@ -16,10 +16,13 @@ public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
     @Value("${es.host}")
     private String host;
 
+    @Value("${es.port}")
+    private String port;
+
     @Override
     public RestHighLevelClient elasticsearchClient() {
         ClientConfiguration clientConfiguration = ClientConfiguration.builder()
-                .connectedTo(host)
+                .connectedTo(host + ":" + port)
                 .build();
         return RestClients.create(clientConfiguration).rest();
     }

--- a/a_uction/src/main/java/com/example/a_uction/controller/auction/AuctionController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/auction/AuctionController.java
@@ -5,7 +5,7 @@ import com.example.a_uction.exception.AuctionException;
 import com.example.a_uction.exception.constants.ErrorCode;
 import com.example.a_uction.model.auction.constants.AuctionStatus;
 import com.example.a_uction.model.auction.dto.AuctionDto;
-import com.example.a_uction.service.auction.AuctionSearchService;
+import com.example.a_uction.service.search.AuctionSearchService;
 import com.example.a_uction.service.auction.AuctionService;
 import java.security.Principal;
 import java.util.List;

--- a/a_uction/src/main/java/com/example/a_uction/controller/search/AuctionSearchController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/search/AuctionSearchController.java
@@ -1,11 +1,12 @@
-package com.example.a_uction.controller.auction;
+package com.example.a_uction.controller.search;
 
 
 import com.example.a_uction.model.auction.constants.Category;
 import com.example.a_uction.model.auction.constants.ItemStatus;
-import com.example.a_uction.model.auction.dto.AuctionDocumentResponse;
-import com.example.a_uction.model.auction.dto.SearchCondition;
-import com.example.a_uction.service.auction.AuctionSearchService;
+import com.example.a_uction.model.auctionSearch.dto.AuctionDocumentResponse;
+import com.example.a_uction.model.auctionSearch.dto.ItemNameSearchCondition;
+import com.example.a_uction.model.auctionSearch.dto.SearchCondition;
+import com.example.a_uction.service.search.AuctionSearchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -60,8 +61,8 @@ public class AuctionSearchController {
 
     //item
     @GetMapping("/auctions/itemName/startWith")
-    public ResponseEntity<Page<AuctionDocumentResponse>> searchByStartWithItemName(@RequestParam String itemName, Pageable pageable){
-        return ResponseEntity.ok(auctionSearchService.findByStartWithItemName(itemName,pageable));
+    public ResponseEntity<Page<AuctionDocumentResponse>> searchByStartWithItemName(ItemNameSearchCondition condition, Pageable pageable){
+        return ResponseEntity.ok(auctionSearchService.findByStartWithItemName(condition, pageable));
     }
 
     //description match

--- a/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/dto/AuctionDocumentResponse.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/dto/AuctionDocumentResponse.java
@@ -1,10 +1,10 @@
-package com.example.a_uction.model.auction.dto;
+package com.example.a_uction.model.auctionSearch.dto;
 
 
 import com.example.a_uction.model.auction.constants.Category;
 import com.example.a_uction.model.auction.constants.ItemStatus;
 import com.example.a_uction.model.auction.constants.TransactionStatus;
-import com.example.a_uction.model.auction.entity.AuctionDocument;
+import com.example.a_uction.model.auctionSearch.entity.AuctionDocument;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/dto/ItemNameSearchCondition.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/dto/ItemNameSearchCondition.java
@@ -1,0 +1,15 @@
+package com.example.a_uction.model.auctionSearch.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@Setter
+public class ItemNameSearchCondition {
+
+    private String itemName;
+    private String sortProperties;
+    private Sort.Direction direction;
+
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/dto/SearchCondition.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/dto/SearchCondition.java
@@ -1,4 +1,4 @@
-package com.example.a_uction.model.auction.dto;
+package com.example.a_uction.model.auctionSearch.dto;
 
 import com.example.a_uction.model.auction.constants.Category;
 import com.example.a_uction.model.auction.constants.ItemStatus;

--- a/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/entity/AuctionDocument.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/entity/AuctionDocument.java
@@ -1,8 +1,9 @@
-package com.example.a_uction.model.auction.entity;
+package com.example.a_uction.model.auctionSearch.entity;
 
 import com.example.a_uction.model.auction.constants.Category;
 import com.example.a_uction.model.auction.constants.ItemStatus;
 import com.example.a_uction.model.auction.constants.TransactionStatus;
+import com.example.a_uction.model.auction.entity.AuctionEntity;
 import lombok.*;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;

--- a/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/repository/AuctionSearchQueryRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/repository/AuctionSearchQueryRepository.java
@@ -1,8 +1,9 @@
-package com.example.a_uction.model.auction.repository;
+package com.example.a_uction.model.auctionSearch.repository;
 
 
-import com.example.a_uction.model.auction.dto.SearchCondition;
-import com.example.a_uction.model.auction.entity.AuctionDocument;
+import com.example.a_uction.model.auctionSearch.dto.ItemNameSearchCondition;
+import com.example.a_uction.model.auctionSearch.dto.SearchCondition;
+import com.example.a_uction.model.auctionSearch.entity.AuctionDocument;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -68,10 +69,20 @@ public class AuctionSearchQueryRepository {
         return query;
     }
 
-    public Page<AuctionDocument> findByStartWithItemName(String itemName, Pageable pageable) {
-        Criteria criteria = Criteria.where("itemName").startsWith(itemName);
+    public Page<AuctionDocument> findByStartWithItemName(ItemNameSearchCondition condition, Pageable pageable) {
+        Criteria criteria = Criteria.where("itemName").startsWith(condition.getItemName());
+        String properties = "id";
+        Sort.Direction direction = Sort.Direction.ASC;
+
+        if (StringUtils.hasText(condition.getSortProperties())){
+            properties = condition.getSortProperties();
+        }
+        if(condition.getDirection() != null){
+            direction = condition.getDirection();
+        }
+
         Query query = new CriteriaQuery(criteria)
-                .addSort(Sort.by(Sort.Direction.ASC, "id")).setPageable(pageable);
+                .addSort(Sort.by(direction, properties)).setPageable(pageable);
         SearchHits<AuctionDocument> search = operations.search(query, AuctionDocument.class);
         return new PageImpl<>(search.stream().map(SearchHit::getContent).collect(Collectors.toList()));
     }

--- a/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/repository/AuctionSearchRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/repository/AuctionSearchRepository.java
@@ -1,8 +1,8 @@
-package com.example.a_uction.model.auction.repository;
+package com.example.a_uction.model.auctionSearch.repository;
 
 import com.example.a_uction.model.auction.constants.Category;
 import com.example.a_uction.model.auction.constants.ItemStatus;
-import com.example.a_uction.model.auction.entity.AuctionDocument;
+import com.example.a_uction.model.auctionSearch.entity.AuctionDocument;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;

--- a/a_uction/src/main/java/com/example/a_uction/service/search/AuctionSearchService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/search/AuctionSearchService.java
@@ -1,15 +1,16 @@
-package com.example.a_uction.service.auction;
+package com.example.a_uction.service.search;
 
 
 import com.example.a_uction.exception.AuctionException;
 import com.example.a_uction.model.auction.constants.Category;
 import com.example.a_uction.model.auction.constants.ItemStatus;
-import com.example.a_uction.model.auction.dto.AuctionDocumentResponse;
-import com.example.a_uction.model.auction.dto.SearchCondition;
-import com.example.a_uction.model.auction.entity.AuctionDocument;
+import com.example.a_uction.model.auctionSearch.dto.AuctionDocumentResponse;
+import com.example.a_uction.model.auctionSearch.dto.ItemNameSearchCondition;
+import com.example.a_uction.model.auctionSearch.dto.SearchCondition;
+import com.example.a_uction.model.auctionSearch.entity.AuctionDocument;
 import com.example.a_uction.model.auction.repository.AuctionRepository;
-import com.example.a_uction.model.auction.repository.AuctionSearchQueryRepository;
-import com.example.a_uction.model.auction.repository.AuctionSearchRepository;
+import com.example.a_uction.model.auctionSearch.repository.AuctionSearchQueryRepository;
+import com.example.a_uction.model.auctionSearch.repository.AuctionSearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -65,8 +66,8 @@ public class AuctionSearchService {
                 .map(AuctionDocumentResponse::from);
     }
 
-    public Page<AuctionDocumentResponse> findByStartWithItemName(String itemName, Pageable pageable) {
-        return auctionSearchQueryRepository.findByStartWithItemName(itemName, pageable)
+    public Page<AuctionDocumentResponse> findByStartWithItemName(ItemNameSearchCondition condition, Pageable pageable) {
+        return auctionSearchQueryRepository.findByStartWithItemName(condition, pageable)
                 .map(AuctionDocumentResponse::from);
     }
 

--- a/a_uction/src/test/java/com/example/a_uction/controller/auction/AuctionControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/auction/AuctionControllerTest.java
@@ -23,7 +23,7 @@ import com.example.a_uction.model.auction.dto.AuctionDto;
 import com.example.a_uction.model.auction.entity.AuctionEntity;
 import com.example.a_uction.model.user.entity.UserEntity;
 import com.example.a_uction.security.jwt.JwtProvider;
-import com.example.a_uction.service.auction.AuctionSearchService;
+import com.example.a_uction.service.search.AuctionSearchService;
 import com.example.a_uction.service.auction.AuctionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.FileInputStream;

--- a/elastic-search.http
+++ b/elastic-search.http
@@ -22,3 +22,5 @@ GET http://localhost:8081/search/auctions/description/matches?description=애플
 ###description contains
 GET http://localhost:8081/search/auctions/description/contains?description=iphone&page=0&size=20
 
+###item name
+GET localhost:8081/search/auctions/itemName/startWith?itemName=아이폰&direction=DESC&page=0&size=20


### PR DESCRIPTION
change
---
1. item name 검색시 정렬 조건 추가
   1. 기존 :  item name 으로 검색 시 Id 기준으로 정렬
   2. 변경 : ItemNameSearchCondition 를 추가하여 정렬조건 설정 가능
2. example
   1.  ~/startWith?itemName=아이폰&page=0&size=20 → id 기준으로 오름차순
   2. ~/startWith?itemName=아이폰&**direction=DESC**&page=0&size=20 → id 기준으로 내림차순
   3. ~/startWith?itemName=아이폰&**sortProperties=startingPrice**&page=0&size=20 → startingPrice 기준으로 오름차순
   4. ~/startWith?itemName=아이폰&**sortProperties=startingPrice**&**direction=DESC**&page=0&size=20 → startingPrice 기준으로 내림차순

3. 추후 확장성을 위해서 sortProperties 을 사용하였습니다. (정렬기준 변경 가능 하도록)
4. package refactoring
5. elastic config 부분 host 를 하기내용처럼 수정하였습니다.
```
@Value("${es.host}") 
private String host;

@Value("${es.port}")
private String port;
```

To reviewer
---
yml 파일에 하기 내용 추가 부탁 드립니다.
localhost 부분에는 저희 배포 ip 주소로 명기하시면 됩니다.

```
es:
  host: localhost
  port: 9200
```

closes #110 