### PR TITLE
Feat/#116/wish list/0 관심등록 구현

### DIFF
--- a/a_uction/src/main/java/com/example/a_uction/controller/wish/WishController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/wish/WishController.java
@@ -25,7 +25,7 @@ public class WishController {
         return ResponseEntity.ok(wishService.addWishAuction(auctionId, principal.getName()));
     }
 
-    @GetMapping("/myList")
+    @GetMapping("/my-list")
     public ResponseEntity<Page<AuctionDto.Response>> getUserWishList(Principal principal, Pageable pageable){
         return ResponseEntity.ok(wishService.getUserWishList(principal.getName(), pageable));
     }

--- a/a_uction/src/main/java/com/example/a_uction/controller/wish/WishController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/wish/WishController.java
@@ -1,0 +1,44 @@
+package com.example.a_uction.controller.wish;
+
+import com.example.a_uction.model.auction.dto.AuctionDto;
+import com.example.a_uction.model.wishList.dto.WishListResponse;
+import com.example.a_uction.service.wish.WishService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/wish")
+@RequiredArgsConstructor
+@Slf4j
+public class WishController {
+
+    private final WishService wishService;
+
+    @PostMapping("/{auctionId}")
+    public ResponseEntity<WishListResponse> addWish(@PathVariable Long auctionId, Principal principal){
+        return ResponseEntity.ok(wishService.addWishAuction(auctionId, principal.getName()));
+    }
+
+    @GetMapping("/myList")
+    public ResponseEntity<Page<AuctionDto.Response>> getUserWishList(Principal principal, Pageable pageable){
+        return ResponseEntity.ok(wishService.getUserWishList(principal.getName(), pageable));
+    }
+
+    @GetMapping("/auction/{auctionId}")
+    public ResponseEntity<Page<String>> getWishUserListAboutAuction(@PathVariable Long auctionId,
+                                                                    Principal principal, Pageable pageable){
+        return ResponseEntity.ok(
+                wishService.getWishUserListAboutAuction(auctionId, principal.getName(), pageable));
+    }
+
+    @DeleteMapping("/{auctionId}")
+    public ResponseEntity<WishListResponse> deleteWish(@PathVariable Long auctionId, Principal principal){
+        return ResponseEntity.ok(wishService.deleteWishAuction(auctionId, principal.getName()));
+    }
+}

--- a/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
+++ b/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
@@ -61,7 +61,13 @@ public enum ErrorCode {
 	LAST_BIDDER_SAME(BAD_REQUEST, "마지막 입찰자가 본인입니다."),
 	UNABLE_CREATE_BID(BAD_REQUEST, "입찰에 실패했습니다."),
 	BIDDING_NOT_FOUND(BAD_REQUEST, "입찰이 없습니다."),
-	AUCTION_NOT_FINISHED(BAD_REQUEST, "아직 입찰이 진행중입니다.")
+	AUCTION_NOT_FINISHED(BAD_REQUEST, "아직 입찰이 진행중입니다."),
+
+
+	//wish
+	WISH_LIST_IS_EMPTY(BAD_REQUEST, "관심 등록한 경매 리스트가 없습니다."),
+	ALREADY_EXIST_WISH_ITEM(BAD_REQUEST, "해당 물품을 이미 관심 등록하였습니다."),
+	UNABLE_DELETE_WISH_LIST(BAD_REQUEST, "해당 물품을 삭제할 수 없습니다."),
 	;
 	private final HttpStatus httpStatus;
 	private final String description;

--- a/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
+++ b/a_uction/src/main/java/com/example/a_uction/exception/constants/ErrorCode.java
@@ -66,8 +66,9 @@ public enum ErrorCode {
 
 	//wish
 	WISH_LIST_IS_EMPTY(BAD_REQUEST, "관심 등록한 경매 리스트가 없습니다."),
-	ALREADY_EXIST_WISH_ITEM(BAD_REQUEST, "해당 물품을 이미 관심 등록하였습니다."),
-	UNABLE_DELETE_WISH_LIST(BAD_REQUEST, "해당 물품을 삭제할 수 없습니다."),
+	NOT_EXIST_WISH_LIST_BY_USER(BAD_REQUEST, "해당 경매를 관심 등록한 유저가 없습니다."),
+	ALREADY_EXIST_WISH_ITEM(BAD_REQUEST, "해당 경매를 이미 관심 등록하였습니다."),
+	UNABLE_DELETE_WISH_LIST(BAD_REQUEST, "관심 리스트에서 삭제할 수 없습니다."),
 	;
 	private final HttpStatus httpStatus;
 	private final String description;

--- a/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auction/entity/AuctionEntity.java
@@ -5,28 +5,16 @@ import com.example.a_uction.model.auction.constants.ItemStatus;
 import com.example.a_uction.model.auction.constants.TransactionStatus;
 import com.example.a_uction.model.auction.dto.AuctionDto;
 import com.example.a_uction.model.user.entity.UserEntity;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OrderColumn;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.example.a_uction.model.wishList.entity.WishListEntity;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -67,6 +55,9 @@ public class AuctionEntity {
     @Builder.Default
     @OrderColumn
     private List<String> imagesSrc = new ArrayList<>();
+
+    @OneToMany(mappedBy = "wishAuction")
+    private List<WishListEntity> wishListForUser = new ArrayList<>();
 
     public void updateEntity(AuctionDto.Request updateAuction) {
         this.setItemName(updateAuction.getItemName());

--- a/a_uction/src/main/java/com/example/a_uction/model/user/entity/UserEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/user/entity/UserEntity.java
@@ -4,16 +4,11 @@ import com.example.a_uction.model.auction.entity.AuctionEntity;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import com.example.a_uction.model.user.dto.ModifyUser;
+import com.example.a_uction.model.wishList.entity.WishListEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -56,6 +51,9 @@ public class UserEntity {
 	private LocalDateTime updateDateTime;
 
 	private String description;
+
+	@OneToMany(mappedBy = "wishUser")
+	private List<WishListEntity> wishList = new ArrayList<>();
 
 	public void updateUserEntity(ModifyUser.Request updateRequest){
 		this.setUsername(updateRequest.getUsername());

--- a/a_uction/src/main/java/com/example/a_uction/model/wishList/dto/WishListResponse.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/wishList/dto/WishListResponse.java
@@ -1,0 +1,23 @@
+package com.example.a_uction.model.wishList.dto;
+
+import com.example.a_uction.model.wishList.entity.WishListEntity;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WishListResponse {
+    private Long id;
+    private String userEmail;
+    private String itemName;
+
+    public WishListResponse fromEntity(WishListEntity wishListEntity){
+        return WishListResponse.builder()
+                .id(wishListEntity.getId())
+                .userEmail(wishListEntity.getWishUser().getUserEmail())
+                .itemName(wishListEntity.getWishAuction().getItemName())
+                .build();
+    }
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/wishList/entity/WishListEntity.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/wishList/entity/WishListEntity.java
@@ -1,0 +1,27 @@
+package com.example.a_uction.model.wishList.entity;
+
+import com.example.a_uction.model.auction.entity.AuctionEntity;
+import com.example.a_uction.model.user.entity.UserEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class WishListEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity wishUser;
+
+    @ManyToOne
+    @JoinColumn(name = "auction_id")
+    private AuctionEntity wishAuction;
+}

--- a/a_uction/src/main/java/com/example/a_uction/model/wishList/repository/WishRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/wishList/repository/WishRepository.java
@@ -1,0 +1,12 @@
+package com.example.a_uction.model.wishList.repository;
+
+import com.example.a_uction.model.wishList.entity.WishListEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface WishRepository extends JpaRepository<WishListEntity, Long> {
+    Optional<WishListEntity> findByWishUserIdAndWishAuctionAuctionId(Long userId, Long auctionId);
+}

--- a/a_uction/src/main/java/com/example/a_uction/service/auction/AuctionService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/auction/AuctionService.java
@@ -1,19 +1,5 @@
 package com.example.a_uction.service.auction;
 
-import static com.example.a_uction.exception.constants.ErrorCode.AUCTION_NOT_FINISHED;
-import static com.example.a_uction.exception.constants.ErrorCode.AUCTION_NOT_FOUND;
-import static com.example.a_uction.exception.constants.ErrorCode.BEFORE_START_TIME;
-import static com.example.a_uction.exception.constants.ErrorCode.BIDDING_NOT_FOUND;
-import static com.example.a_uction.exception.constants.ErrorCode.END_TIME_EARLIER_THAN_START_TIME;
-import static com.example.a_uction.exception.constants.ErrorCode.NOT_FOUND_AUCTION_LIST;
-import static com.example.a_uction.exception.constants.ErrorCode.NOT_FOUND_AUCTION_STATUS_LIST;
-import static com.example.a_uction.exception.constants.ErrorCode.UNABLE_DELETE_AUCTION;
-import static com.example.a_uction.exception.constants.ErrorCode.UNABLE_UPDATE_AUCTION;
-import static com.example.a_uction.exception.constants.ErrorCode.USER_NOT_FOUND;
-import static com.example.a_uction.model.auction.constants.AuctionStatus.COMPLETED;
-import static com.example.a_uction.model.auction.constants.AuctionStatus.PROCEEDING;
-import static com.example.a_uction.model.auction.constants.AuctionStatus.SCHEDULED;
-
 import com.example.a_uction.exception.AuctionException;
 import com.example.a_uction.exception.constants.ErrorCode;
 import com.example.a_uction.model.auction.constants.AuctionStatus;
@@ -28,13 +14,17 @@ import com.example.a_uction.model.biddingHistory.entity.BiddingHistoryEntity;
 import com.example.a_uction.model.biddingHistory.repository.BiddingHistoryRepository;
 import com.example.a_uction.model.user.entity.UserEntity;
 import com.example.a_uction.model.user.repository.UserRepository;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.a_uction.exception.constants.ErrorCode.*;
+import static com.example.a_uction.model.auction.constants.AuctionStatus.*;
 
 @Service
 @RequiredArgsConstructor

--- a/a_uction/src/main/java/com/example/a_uction/service/wish/WishService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/wish/WishService.java
@@ -77,9 +77,13 @@ public class WishService {
     }
 
     public Page<String> getWishUserListAboutAuction(Long auctionId, String userEmail, Pageable pageable){
-        AuctionEntity result = auctionRepository.getByAuctionId(auctionId);
-        if(result.getUser().getUserEmail().equals(userEmail)){
-            List<String> userList = result.getWishListForUser().stream()
+        AuctionEntity auction = auctionRepository.getByAuctionId(auctionId);
+        if(auction.getWishListForUser().size() == 0){
+            throw new AuctionException(NOT_EXIST_WISH_LIST_BY_USER);
+        }
+
+        if(auction.getUser().getUserEmail().equals(userEmail)){
+            List<String> userList = auction.getWishListForUser().stream()
                     .map(m -> m.getWishUser().getUserEmail())
                     .collect(Collectors.toList());
 
@@ -88,7 +92,7 @@ public class WishService {
 
             return new PageImpl<>(userList.subList(start, end), pageable, userList.size());
         }
-        return new PageImpl<>(List.of(String.valueOf(result.getWishListForUser().size())));
+        return new PageImpl<>(List.of(String.valueOf(auction.getWishListForUser().size())));
     }
 
     public WishListResponse deleteWishAuction(Long auctionId, String userEmail) {

--- a/a_uction/src/main/java/com/example/a_uction/service/wish/WishService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/wish/WishService.java
@@ -1,0 +1,101 @@
+package com.example.a_uction.service.wish;
+
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.model.auction.dto.AuctionDto;
+import com.example.a_uction.model.auction.entity.AuctionEntity;
+import com.example.a_uction.model.auction.repository.AuctionRepository;
+import com.example.a_uction.model.user.entity.UserEntity;
+import com.example.a_uction.model.user.repository.UserRepository;
+import com.example.a_uction.model.wishList.dto.WishListResponse;
+import com.example.a_uction.model.wishList.entity.WishListEntity;
+import com.example.a_uction.model.wishList.repository.WishRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.example.a_uction.exception.constants.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WishService {
+
+    private final WishRepository wishRepository;
+    private final UserRepository userRepository;
+    private final AuctionRepository auctionRepository;
+
+    private UserEntity getUser(String userEmail) {
+        return userRepository.getByUserEmail(userEmail);
+    }
+
+    private AuctionEntity getAuction(Long auctionId) {
+        return auctionRepository.getByAuctionId(auctionId);
+    }
+
+    private Optional<WishListEntity> existWishList(Long auctionId, Long userId){
+        return wishRepository.findByWishUserIdAndWishAuctionAuctionId(userId, auctionId);
+    }
+
+    public WishListResponse addWishAuction(Long auctionId, String userEmail){
+        UserEntity user = getUser(userEmail);
+        Optional<WishListEntity> wishCheck = existWishList(auctionId, user.getId());
+
+        if(wishCheck.isPresent()){
+            throw new AuctionException(ALREADY_EXIST_WISH_ITEM);
+        }
+
+        return new WishListResponse().fromEntity(wishRepository.save(
+                WishListEntity.builder()
+                        .wishAuction(getAuction(auctionId))
+                        .wishUser(user)
+                        .build())
+        );
+    }
+
+    public Page<AuctionDto.Response> getUserWishList(String userEmail, Pageable pageable) {
+        UserEntity user = getUser(userEmail);
+
+        if(user.getWishList().size() == 0){
+            throw new AuctionException(WISH_LIST_IS_EMPTY);
+        }
+
+        List<AuctionDto.Response> wishList = user.getWishList().stream()
+                .map((WishListEntity m) -> AuctionDto.Response.fromEntity(m.getWishAuction()))
+                .collect(Collectors.toList());
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), wishList.size());
+
+        return new PageImpl<>(wishList.subList(start, end), pageable, wishList.size());
+    }
+
+    public Page<String> getWishUserListAboutAuction(Long auctionId, String userEmail, Pageable pageable){
+        AuctionEntity result = auctionRepository.getByAuctionId(auctionId);
+        if(result.getUser().getUserEmail().equals(userEmail)){
+            List<String> userList = result.getWishListForUser().stream()
+                    .map(m -> m.getWishUser().getUserEmail())
+                    .collect(Collectors.toList());
+
+            int start = (int) pageable.getOffset();
+            int end = Math.min((start + pageable.getPageSize()), userList.size());
+
+            return new PageImpl<>(userList.subList(start, end), pageable, userList.size());
+        }
+        return new PageImpl<>(List.of(String.valueOf(result.getWishListForUser().size())));
+    }
+
+    public WishListResponse deleteWishAuction(Long auctionId, String userEmail) {
+        UserEntity user = getUser(userEmail);
+        WishListEntity wishCheck = existWishList(auctionId, user.getId())
+                .orElseThrow(() -> new AuctionException(UNABLE_DELETE_WISH_LIST));
+        wishRepository.delete(wishCheck);
+        return new WishListResponse().fromEntity(wishCheck);
+    }
+}

--- a/a_uction/src/test/java/com/example/a_uction/controller/wish/WishControllerTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/controller/wish/WishControllerTest.java
@@ -1,0 +1,244 @@
+package com.example.a_uction.controller.wish;
+
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.model.auction.dto.AuctionDto;
+import com.example.a_uction.model.wishList.dto.WishListResponse;
+import com.example.a_uction.security.jwt.JwtProvider;
+import com.example.a_uction.service.wish.WishService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.a_uction.exception.constants.ErrorCode.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(WishController.class)
+class WishControllerTest {
+    @MockBean
+    private WishService wishService;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+    @MockBean
+    private RedisTemplate<String, Object> redisTemplate;
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("관심 등록 - 성공")
+    @WithMockUser
+    void addWishSuccess() throws Exception {
+        //given
+        WishListResponse response = WishListResponse.builder()
+                .id(1L)
+                .userEmail("test@test.com")
+                .itemName("test item")
+                .build();
+
+        given(wishService.addWishAuction(anyLong(),any())).willReturn(response);
+
+        //when
+        //then
+        mockMvc.perform(post("/wish/" + 1L).with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("$.id").value("1"))
+                .andExpect(jsonPath("$.userEmail").value("test@test.com"))
+                .andExpect(jsonPath("$.itemName").value("test item"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("관심 등록 - 실패")
+    @WithMockUser
+    void addWishFail() throws Exception {
+        //given
+        given(wishService.addWishAuction(anyLong(), any()))
+                .willThrow(new AuctionException(ALREADY_EXIST_WISH_ITEM));
+
+        //when
+        //then
+        mockMvc.perform(post("/wish/" + 1L).with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("$.errorCode").value("ALREADY_EXIST_WISH_ITEM"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("회원 관심 리스트 - 성공")
+    @WithMockUser
+    void getUserWishList() throws Exception {
+        //given
+        List<AuctionDto.Response> responseList = List.of(
+                AuctionDto.Response.builder()
+                        .auctionId(1L)
+                        .description("this is test1")
+                        .itemName("test1")
+                        .minimumBid(100)
+                        .startingPrice(1000)
+                        .startDateTime(LocalDateTime.parse("2024-04-15T17:09:42.411"))
+                        .endDateTime(LocalDateTime.parse("2024-04-15T17:10:42.411"))
+                        .build(),
+                AuctionDto.Response.builder()
+                        .auctionId(2L)
+                        .description("this is test2")
+                        .itemName("test2")
+                        .minimumBid(200)
+                        .startingPrice(2000)
+                        .startDateTime(LocalDateTime.parse("2024-04-15T17:09:42.411"))
+                        .endDateTime(LocalDateTime.parse("2024-04-15T17:10:42.411"))
+                        .build());
+
+        Page<AuctionDto.Response> page = new PageImpl<>(responseList);
+
+        given(wishService.getUserWishList(any(), any())).willReturn(page);
+
+        //when
+        //then
+        mockMvc.perform(get("/wish/my-list").with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("$.numberOfElements").value(2))
+                .andExpect(jsonPath("$.content[0].auctionId").value(1))
+                .andExpect(jsonPath("$.content[0].itemName").value("test1"))
+                .andExpect(jsonPath("$.content[0].minimumBid").value(100))
+                .andExpect(jsonPath("$.content[0].startingPrice").value(1000))
+                .andExpect(jsonPath("$.content[0].description").value("this is test1"))
+                .andExpect(jsonPath("$.content[1].auctionId").value(2))
+                .andExpect(jsonPath("$.content[1].itemName").value("test2"))
+                .andExpect(jsonPath("$.content[1].minimumBid").value(200))
+                .andExpect(jsonPath("$.content[1].startingPrice").value(2000))
+                .andExpect(jsonPath("$.content[1].description").value("this is test2"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("회원 관심 리스트 -실패")
+    @WithMockUser
+    void getUserWishListFail() throws Exception {
+        //given
+        given(wishService.getUserWishList(any(), any())).willThrow(new AuctionException(WISH_LIST_IS_EMPTY));
+
+        //when
+        //then
+        mockMvc.perform(get("/wish/my-list").with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("$.errorCode").value("WISH_LIST_IS_EMPTY"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("경매에 관심 있는 유저 리스트 - 성공 - 경매 등록자")
+    @WithMockUser
+    void getWishUserListAboutAuctionSuccess() throws Exception{
+        //given
+        List<String> userList = List.of("test1", "test2", "test3");
+        Page<String> userPage = new PageImpl<>(userList);
+
+        given(wishService.getWishUserListAboutAuction(anyLong(), any(), any())).willReturn(userPage);
+
+        //when
+        //then
+        mockMvc.perform(get("/wish/auction/" + 1L).with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.content[0]").value("test1"))
+                .andExpect(jsonPath("$.content[1]").value("test2"))
+                .andExpect(jsonPath("$.content[2]").value("test3"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("경매에 관심 있는 유저 리스트 - 성공 - 사용자")
+    @WithMockUser
+    void getWishUserListAboutAuctionSuccessUser() throws Exception{
+        //given
+        List<String> userList = List.of("3");
+        Page<String> userPage = new PageImpl<>(userList);
+
+        given(wishService.getWishUserListAboutAuction(anyLong(), any(), any())).willReturn(userPage);
+
+        //when
+        //then
+        mockMvc.perform(get("/wish/auction/" + 1L).with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.content[0]").value("3"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("경매에 관심 있는 유저 리스트 - 실패")
+    @WithMockUser
+    void getWishUserListAboutAuctionFail() throws Exception{
+        //given
+        given(wishService.getWishUserListAboutAuction(anyLong(), any(), any()))
+                .willThrow(new AuctionException(NOT_EXIST_WISH_LIST_BY_USER));
+        //when
+        //then
+        mockMvc.perform(get("/wish/auction/" + 1L).with(csrf()))
+                .andDo(print())
+                .andExpect(jsonPath("$.errorCode").value("NOT_EXIST_WISH_LIST_BY_USER"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("관심등록 삭제 - 성공")
+    @WithMockUser
+    void deleteWishSuccess() throws Exception {
+        //given
+        WishListResponse response = WishListResponse.builder()
+                .id(1L)
+                .userEmail("test@test.com")
+                .itemName("test item")
+                .build();
+
+        given(wishService.deleteWishAuction(anyLong(),any())).willReturn(response);
+        //when
+        //then
+        mockMvc.perform(delete("/wish/" + 1L).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(jsonPath("$.id").value("1"))
+                .andExpect(jsonPath("$.userEmail").value("test@test.com"))
+                .andExpect(jsonPath("$.itemName").value("test item"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("관심등록 삭제 - 실패")
+    @WithMockUser
+    void deleteWishFail() throws Exception {
+        //given
+        given(wishService.deleteWishAuction(anyLong(),any()))
+                .willThrow(new AuctionException(UNABLE_DELETE_WISH_LIST));
+
+        //when
+        //then
+        mockMvc.perform(delete("/wish/" + 1L).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(jsonPath("$.errorCode").value("UNABLE_DELETE_WISH_LIST"))
+                .andExpect(status().isOk());
+    }
+}

--- a/a_uction/src/test/java/com/example/a_uction/service/wish/WishServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/wish/WishServiceTest.java
@@ -1,0 +1,343 @@
+package com.example.a_uction.service.wish;
+
+import com.example.a_uction.exception.AuctionException;
+import com.example.a_uction.model.auction.constants.ItemStatus;
+import com.example.a_uction.model.auction.entity.AuctionEntity;
+import com.example.a_uction.model.auction.repository.AuctionRepository;
+import com.example.a_uction.model.user.entity.UserEntity;
+import com.example.a_uction.model.user.repository.UserRepository;
+import com.example.a_uction.model.wishList.entity.WishListEntity;
+import com.example.a_uction.model.wishList.repository.WishRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.a_uction.exception.constants.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WishServiceTest {
+    @InjectMocks
+    private WishService wishService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private AuctionRepository auctionRepository;
+    @Mock
+    private WishRepository wishRepository;
+
+
+
+    @Test
+    @DisplayName("관심 등록 - 성공")
+    void addWishAuctionSuccess() {
+        //given
+        UserEntity user = UserEntity.builder()
+                .id(1L)
+                .userEmail("test@test.com")
+                .build();
+
+        AuctionEntity auction = AuctionEntity.builder()
+                .auctionId(1L)
+                .itemName("test item")
+                .itemStatus(ItemStatus.BAD)
+                .startingPrice(2000)
+                .minimumBid(200)
+                .startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
+                .endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
+                .description("this is test")
+                .build();
+
+        given(userRepository.getByUserEmail(any())).willReturn(user);
+        given(wishRepository.findByWishUserIdAndWishAuctionAuctionId(any(), any()))
+                .willReturn(Optional.empty());
+        given(wishRepository.save(any())).willReturn(WishListEntity.builder()
+                    .id(1L)
+                    .wishAuction(auction)
+                    .wishUser(user)
+                .build());
+
+        //when
+
+        var result = wishService.addWishAuction(1L, "test@test.com");
+
+        //then
+        assertEquals(1L, result.getId());
+        assertEquals("test@test.com", result.getUserEmail());
+        assertEquals("test item", result.getItemName());
+    }
+
+    @Test
+    @DisplayName("관심 등록 - 실패")
+    void addWishAuctionFail() {
+        //given
+        UserEntity user = UserEntity.builder()
+                .id(1L)
+                .userEmail("test@test.com")
+                .build();
+
+        AuctionEntity auction = AuctionEntity.builder()
+                .auctionId(1L)
+                .itemName("test item")
+                .itemStatus(ItemStatus.BAD)
+                .startingPrice(2000)
+                .minimumBid(200)
+                .startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
+                .endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
+                .description("this is test")
+                .build();
+
+        given(userRepository.getByUserEmail(any())).willReturn(user);
+        given(wishRepository.findByWishUserIdAndWishAuctionAuctionId(any(), any()))
+                .willReturn(Optional.ofNullable(WishListEntity.builder()
+                        .id(1L)
+                        .wishAuction(auction)
+                        .wishUser(user)
+                .build()));
+
+        //when
+        AuctionException exception = assertThrows(AuctionException.class,
+                () -> wishService.addWishAuction(1L, "test@test.com"));
+
+        //then
+        assertEquals(ALREADY_EXIST_WISH_ITEM, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("고객의 관심리스트 가져오기 - 성공")
+    void getUserWishListSuccess() {
+        //given
+        UserEntity user = UserEntity.builder()
+                .id(1L)
+                .userEmail("test@test.com")
+                .wishList(List.of(WishListEntity.builder()
+                        .wishAuction(AuctionEntity.builder()
+                                .auctionId(1L)
+                                .itemName("test item")
+                                .itemStatus(ItemStatus.BAD)
+                                .startingPrice(2000)
+                                .minimumBid(200)
+                                .startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
+                                .endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
+                                .description("this is test")
+                                .build())
+                        .build(), WishListEntity.builder()
+                        .wishAuction(AuctionEntity.builder()
+                                .auctionId(2L)
+                                .itemName("test item2")
+                                .itemStatus(ItemStatus.GOOD)
+                                .startingPrice(2000)
+                                .minimumBid(200)
+                                .startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
+                                .endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
+                                .description("this is test2")
+                                .build())
+                        .build()))
+                .build();
+
+        given(userRepository.getByUserEmail(any())).willReturn(user);
+
+
+        //when
+        var result = wishService.getUserWishList("test@test.com", Pageable.ofSize(10));
+
+        //then
+        assertEquals(1L, result.toList().get(0).getAuctionId());
+        assertEquals("test item", result.toList().get(0).getItemName());
+        assertEquals("this is test", result.toList().get(0).getDescription());
+        assertEquals(2000, result.toList().get(0).getStartingPrice());
+        assertEquals(2L, result.toList().get(1).getAuctionId());
+        assertEquals("test item2", result.toList().get(1).getItemName());
+        assertEquals("this is test2", result.toList().get(1).getDescription());
+        assertEquals(2000, result.toList().get(1).getStartingPrice());
+
+    }
+
+    @Test
+    @DisplayName("고객의 관심리스트 가져오기 - 실패")
+    void getUserWishListFail() {
+        //given
+        UserEntity user = UserEntity.builder()
+                .id(1L)
+                .userEmail("test@test.com")
+                .wishList(new ArrayList<>())
+                .build();
+
+        given(userRepository.getByUserEmail(any())).willReturn(user);
+
+        //when
+        AuctionException exception = assertThrows(AuctionException.class,
+                () -> wishService.getUserWishList("test@test.com", Pageable.ofSize(10)));
+
+        //then
+        assertEquals(WISH_LIST_IS_EMPTY, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("경매에 관심있는 사용자의 리스트 가져오기 - 성공 - 경매 등록자")
+    void getWishUserListAboutAuctionSuccess() {
+        //given
+        AuctionEntity auction = AuctionEntity.builder()
+                .auctionId(1L)
+                .user(UserEntity.builder().id(1L).userEmail("admin").build())
+                .itemName("test item")
+                .itemStatus(ItemStatus.BAD)
+                .startingPrice(2000)
+                .minimumBid(200)
+                .startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
+                .endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
+                .description("this is test")
+                .wishListForUser(List.of(
+                        WishListEntity.builder()
+                                        .wishUser(UserEntity.builder()
+                                                .id(1L).userEmail("test1").build()).build(),
+                        WishListEntity.builder()
+                                .wishUser(UserEntity.builder()
+                                        .id(2L).userEmail("test2").build()).build()))
+                .build();
+
+        given(auctionRepository.getByAuctionId(any())).willReturn(auction);
+
+        //when
+        var result = wishService.getWishUserListAboutAuction(1L, "admin",
+                Pageable.ofSize(10));
+
+        //then
+        assertEquals(2, result.toList().size());
+        assertEquals("test1", result.toList().get(0));
+        assertEquals("test2", result.toList().get(1));
+    }
+
+    @Test
+    @DisplayName("경매에 관심있는 사용자의 리스트 가져오기 - 성공 - 사용자")
+    void getWishUserListAboutAuctionSuccessUser() {
+        //given
+        AuctionEntity auction = AuctionEntity.builder()
+                .auctionId(1L)
+                .user(UserEntity.builder().id(1L).userEmail("admin").build())
+                .itemName("test item")
+                .itemStatus(ItemStatus.BAD)
+                .startingPrice(2000)
+                .minimumBid(200)
+                .startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
+                .endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
+                .description("this is test")
+                .wishListForUser(List.of(
+                        WishListEntity.builder()
+                                .wishUser(UserEntity.builder()
+                                        .id(1L).userEmail("test1").build()).build(),
+                        WishListEntity.builder()
+                                .wishUser(UserEntity.builder()
+                                        .id(2L).userEmail("test2").build()).build()))
+                .build();
+
+        given(auctionRepository.getByAuctionId(any())).willReturn(auction);
+
+        //when
+        var result = wishService.getWishUserListAboutAuction(1L, "user",
+                Pageable.ofSize(10));
+
+        //then
+        assertEquals(1, result.toList().size());
+        assertEquals("2", result.toList().get(0));
+    }
+
+    @Test
+    @DisplayName("경매에 관심있는 사용자의 리스트 가져오기 - 실패")
+    void getWishUserListAboutAuctionFail() {
+        //given
+        AuctionEntity auction = AuctionEntity.builder()
+                .auctionId(1L)
+                .user(UserEntity.builder().id(1L).userEmail("admin").build())
+                .itemName("test item")
+                .itemStatus(ItemStatus.BAD)
+                .startingPrice(2000)
+                .minimumBid(200)
+                .startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
+                .endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
+                .description("this is test")
+                .wishListForUser(new ArrayList<>())
+                .build();
+
+        given(auctionRepository.getByAuctionId(any())).willReturn(auction);
+        //when
+        AuctionException exception = assertThrows(AuctionException.class,
+                () -> wishService.getWishUserListAboutAuction(1L, "admin", Pageable.ofSize(10)));
+
+        //then
+        assertEquals(NOT_EXIST_WISH_LIST_BY_USER, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("관심등록 삭제 - 성공")
+    void deleteWishAuctionSuccess() {
+        //given
+        UserEntity user = UserEntity.builder()
+                .id(1L)
+                .userEmail("test@test.com")
+                .build();
+
+        AuctionEntity auction = AuctionEntity.builder()
+                .auctionId(1L)
+                .user(UserEntity.builder().id(1L).userEmail("admin").build())
+                .itemName("test item")
+                .itemStatus(ItemStatus.BAD)
+                .startingPrice(2000)
+                .minimumBid(200)
+                .startDateTime(LocalDateTime.parse("2025-04-15T17:09:42.411"))
+                .endDateTime(LocalDateTime.parse("2025-04-15T17:10:42.411"))
+                .description("this is test")
+                .wishListForUser(new ArrayList<>())
+                .build();
+
+        WishListEntity wishList = WishListEntity.builder()
+                .id(1L)
+                .wishUser(user)
+                .wishAuction(auction)
+                .build();
+
+        given(userRepository.getByUserEmail(any())).willReturn(user);
+        given(wishRepository.findByWishUserIdAndWishAuctionAuctionId(any(), any()))
+                .willReturn(Optional.ofNullable(wishList));
+
+        //when
+        var result = wishService.deleteWishAuction(1L, "test@test.com");
+
+        //then
+        assertEquals(1L, result.getId());
+        assertEquals("test item", result.getItemName());
+    }
+
+    @Test
+    @DisplayName("관심등록 삭제 - 실패")
+    void deleteWishAuctionFail() {
+        //given
+        UserEntity user = UserEntity.builder()
+                .id(1L)
+                .userEmail("test@test.com")
+                .build();
+
+        given(userRepository.getByUserEmail(any())).willReturn(user);
+        given(wishRepository.findByWishUserIdAndWishAuctionAuctionId(any(), any()))
+                .willThrow(new AuctionException(UNABLE_DELETE_WISH_LIST));
+        //when
+        AuctionException exception = assertThrows(AuctionException.class,
+                () -> wishService.deleteWishAuction(1L, "test@test.com"));
+
+        //then
+        assertEquals(UNABLE_DELETE_WISH_LIST, exception.getErrorCode());
+    }
+}

--- a/auction-wish-api.http
+++ b/auction-wish-api.http
@@ -1,0 +1,15 @@
+###wish
+POST http://localhost:8081/wish/13
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZTNAZ21haWwuY29tIiwic3ViIjoiQWNjZXNzVG9rZW4iLCJpYXQiOjE2ODI1NjYzMTYsImV4cCI6MTY4MjU2OTkxNn0.pEeHJtKbKukWIbVKyxdWor_zpBk_iZvqC6JiaZNjZZA
+
+### getwish
+GET http://localhost:8081/wish/myList?page=2&size=2
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZTNAZ21haWwuY29tIiwic3ViIjoiQWNjZXNzVG9rZW4iLCJpYXQiOjE2ODI1NjYzMTYsImV4cCI6MTY4MjU2OTkxNn0.pEeHJtKbKukWIbVKyxdWor_zpBk_iZvqC6JiaZNjZZA
+
+### getwishAuction
+GET http://localhost:8081/wish/auction/1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZTNAZ21haWwuY29tIiwic3ViIjoiQWNjZXNzVG9rZW4iLCJpYXQiOjE2ODI1NjU1NjksImV4cCI6MTY4MjU2OTE2OX0.Bd5FdNPq_YBIVUZfrMnYR6O96uoUBKNbCHwbhtw-Tl4
+
+### delete wishAuction
+DELETE http://localhost:8081/wish/2
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZTNAZ21haWwuY29tIiwic3ViIjoiQWNjZXNzVG9rZW4iLCJpYXQiOjE2ODI1NjQ3NDEsImV4cCI6MTY4MjU2ODM0MX0.2xVPYckWsJNeTBn148qK3aFZKUBiciTlcgQD0a8vr0E

--- a/auction-wish-api.http
+++ b/auction-wish-api.http
@@ -3,7 +3,7 @@ POST http://localhost:8081/wish/13
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZTNAZ21haWwuY29tIiwic3ViIjoiQWNjZXNzVG9rZW4iLCJpYXQiOjE2ODI1NjYzMTYsImV4cCI6MTY4MjU2OTkxNn0.pEeHJtKbKukWIbVKyxdWor_zpBk_iZvqC6JiaZNjZZA
 
 ### getwish
-GET http://localhost:8081/wish/myList?page=2&size=2
+GET http://localhost:8081/wish/my-list?page=2&size=2
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJ6ZXJvYmFzZTNAZ21haWwuY29tIiwic3ViIjoiQWNjZXNzVG9rZW4iLCJpYXQiOjE2ODI1NjYzMTYsImV4cCI6MTY4MjU2OTkxNn0.pEeHJtKbKukWIbVKyxdWor_zpBk_iZvqC6JiaZNjZZA
 
 ### getwishAuction


### PR DESCRIPTION
change
---
1. 경매 관심 등록 / 삭제 구현
   1. 중복 추가 안됨
2. user 가 관심 등록한 경매 리스트 구현
3. 경매에 관심있는 user list 구현
   1. 경매 등록자 : userEmail list 를 볼 수 있음
   2. 그외(user) : 해당 경매에 관심을 가지는 user 의 수 를 볼수 있음
4. wish Table 생성
   1. wish table ↔ user table 연결
   2. wish table ↔ auction table 연결
   
<img width="874" alt="스크린샷 2023-04-27 오후 3 40 48" src="https://user-images.githubusercontent.com/117243197/234780588-437ba02e-1e39-47ae-980f-3bd1c08ebfb1.png">

5. 테스트 코드 구현 (service, controller)

Background
---
api 명세 해당 내용 추가
인기있는 경매 구현을 관심도를 이용해도 될지 확인 필요

To Reviewer
---
change 의 3번 내용 확인 부탁 드릴게요.
예를 들어 1번 경매의 관심있는 유저리스트를 볼 때 **경매 등록자만 user Email** 을 볼수 있고 **그 외의 사람은 해당 경매에 관심있는 user 의 Total count** 만 볼수 있게 구현해두었습니다.
경매 등록자를 포함한 **모든 사람**이 경매의 관심있는 유저리스트를 볼 때 총 수만 볼수 있게 하는게 좋을지 userEmail 을 볼 수 있게 하는게 좋을지 의견 부탁 드립니다.

추가로 관심 리스트 이름을 정하면서 제가 임의로 wishList 로 명명하였습니다.
이 부분도 의견 부탁 드릴게요~

closes #116 