### PR TITLE
Refactor/#121/search refactor/0

### DIFF
--- a/a_uction/src/main/java/com/example/a_uction/controller/search/AuctionSearchController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/search/AuctionSearchController.java
@@ -23,26 +23,26 @@ public class AuctionSearchController {
     private final AuctionSearchService auctionSearchService;
 
     //es 등록
-    @PostMapping("/auctionDocument/{auctionId}")
+    @PostMapping("/auction-document/{auctionId}")
     public ResponseEntity<Void> saveAuctionDocuments(@PathVariable Long auctionId){
         auctionSearchService.saveAuctionDocument(auctionId);
         return ResponseEntity.ok().build();
     }
 
     //시작금액
-    @GetMapping("/auctions/startingPrice")
+    @GetMapping("/auctions/starting-price")
     public ResponseEntity<Page<AuctionDocumentResponse>> searchByNickname(@RequestParam int startingPrice, Pageable pageable){
         return ResponseEntity.ok(auctionSearchService.findByStartingPrice(startingPrice,pageable));
     }
 
     //minimumBid
-    @GetMapping("/auctions/minimumBid")
+    @GetMapping("/auctions/minimum-bid")
     public ResponseEntity<Page<AuctionDocumentResponse>> searchByMinimumBid(@RequestParam int minimumBid, Pageable pageable){
         return ResponseEntity.ok(auctionSearchService.findByMinimumBid(minimumBid,pageable));
     }
 
     //itemStatus
-    @GetMapping("/auctions/itemStatus")
+    @GetMapping("/auctions/item-status")
     public ResponseEntity<Page<AuctionDocumentResponse>> searchByItemStatus(@RequestParam ItemStatus itemStatus, Pageable pageable){
         return ResponseEntity.ok(auctionSearchService.findByItemStatus(itemStatus,pageable));
     }
@@ -61,7 +61,7 @@ public class AuctionSearchController {
     }
 
     //item
-    @GetMapping("/auctions/itemName/contain")
+    @GetMapping("/auctions/item-name/contain")
     public ResponseEntity<Page<AuctionDocumentResponse>> searchByContainItemName(@RequestParam String itemName,
                                                                                    SortingCondition condition, Pageable pageable){
         return ResponseEntity.ok(auctionSearchService.findByContainItemName(itemName, condition, pageable));
@@ -80,7 +80,7 @@ public class AuctionSearchController {
     }
 
     //delete
-    @DeleteMapping("/auctionDocument/{auctionId}")
+    @DeleteMapping("/auction-document/{auctionId}")
     public ResponseEntity<Void> deleteAuctionDocuments(@PathVariable Long auctionId){
         auctionSearchService.deleteAuctionDocuments(auctionId);
         return ResponseEntity.ok().build();

--- a/a_uction/src/main/java/com/example/a_uction/controller/search/AuctionSearchController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/search/AuctionSearchController.java
@@ -61,10 +61,10 @@ public class AuctionSearchController {
     }
 
     //item
-    @GetMapping("/auctions/itemName/startWith")
-    public ResponseEntity<Page<AuctionDocumentResponse>> searchByStartWithItemName(@RequestParam String itemName,
+    @GetMapping("/auctions/itemName/contain")
+    public ResponseEntity<Page<AuctionDocumentResponse>> searchByContainItemName(@RequestParam String itemName,
                                                                                    SortingCondition condition, Pageable pageable){
-        return ResponseEntity.ok(auctionSearchService.findByStartWithItemName(itemName, condition, pageable));
+        return ResponseEntity.ok(auctionSearchService.findByContainItemName(itemName, condition, pageable));
     }
 
     //description match

--- a/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/repository/AuctionSearchQueryRepository.java
+++ b/a_uction/src/main/java/com/example/a_uction/model/auctionSearch/repository/AuctionSearchQueryRepository.java
@@ -72,8 +72,8 @@ public class AuctionSearchQueryRepository {
         return query;
     }
 
-    public Page<AuctionDocument> findByStartWithItemName(String itemName, SortingCondition condition, Pageable pageable) {
-        Criteria criteria = Criteria.where("itemName").startsWith(itemName);
+    public Page<AuctionDocument> findByContainItemName(String itemName, SortingCondition condition, Pageable pageable) {
+        Criteria criteria = Criteria.where("itemName").contains(itemName);
         return makeQueryWithSort(criteria, condition, pageable);
     }
 

--- a/a_uction/src/main/java/com/example/a_uction/service/auction/AuctionService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/auction/AuctionService.java
@@ -14,6 +14,7 @@ import com.example.a_uction.model.biddingHistory.entity.BiddingHistoryEntity;
 import com.example.a_uction.model.biddingHistory.repository.BiddingHistoryRepository;
 import com.example.a_uction.model.user.entity.UserEntity;
 import com.example.a_uction.model.user.repository.UserRepository;
+import com.example.a_uction.service.search.AuctionSearchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,6 +36,8 @@ public class AuctionService {
 	private final AuctionFileService auctionFileService;
 	private final BiddingHistoryRepository biddingHistoryRepository;
 	private final AuctionTransactionHistoryRepository auctionTransactionHistoryRepository;
+
+	private final AuctionSearchService auctionSearchService;
 
 	private UserEntity getUser(String userEmail) {
 		return userRepository.getByUserEmail(userEmail);
@@ -212,6 +215,8 @@ public class AuctionService {
 		} else {
 			auction.setTransactionStatus(TransactionStatus.TRANSACTION_FAIL);
 		}
+
+		auctionSearchService.deleteAuctionDocuments(auctionId);
 		return AuctionDto.Response.fromEntity(auctionRepository.save(auction));
 	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/service/search/AuctionSearchService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/search/AuctionSearchService.java
@@ -66,8 +66,8 @@ public class AuctionSearchService {
                 .map(AuctionDocumentResponse::from);
     }
 
-    public Page<AuctionDocumentResponse> findByStartWithItemName(String itemName, SortingCondition condition, Pageable pageable) {
-        return auctionSearchQueryRepository.findByStartWithItemName(itemName, condition, pageable)
+    public Page<AuctionDocumentResponse> findByContainItemName(String itemName, SortingCondition condition, Pageable pageable) {
+        return auctionSearchQueryRepository.findByContainItemName(itemName, condition, pageable)
                 .map(AuctionDocumentResponse::from);
     }
 

--- a/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionServiceTest.java
@@ -23,6 +23,8 @@ import com.example.a_uction.model.auction.constants.TransactionStatus;
 import com.example.a_uction.model.auction.dto.AuctionDto;
 import com.example.a_uction.model.auction.entity.AuctionEntity;
 import com.example.a_uction.model.auction.repository.AuctionRepository;
+import com.example.a_uction.model.auctionSearch.repository.AuctionSearchQueryRepository;
+import com.example.a_uction.model.auctionSearch.repository.AuctionSearchRepository;
 import com.example.a_uction.model.auctionTransactionHistory.entity.AuctionTransactionHistoryEntity;
 import com.example.a_uction.model.auctionTransactionHistory.repository.AuctionTransactionHistoryRepository;
 import com.example.a_uction.model.biddingHistory.entity.BiddingHistoryEntity;
@@ -35,6 +37,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import com.example.a_uction.service.search.AuctionSearchService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,6 +72,12 @@ class AuctionServiceTest {
 
 	@InjectMocks
 	private AuctionService auctionService;
+	@Mock
+	private AuctionSearchService auctionSearchService;
+	@Mock
+	private AuctionSearchRepository auctionSearchRepository;
+	@Mock
+	private AuctionSearchQueryRepository auctionSearchQueryRepository;
 
 	private static final String TEST_IMAGE_SRC = "src/test/resources/image/test.png";
 

--- a/elastic-search.http
+++ b/elastic-search.http
@@ -23,5 +23,5 @@ GET http://localhost:8081/search/auctions/description/matches?description=애플
 GET http://localhost:8081/search/auctions/description/contains?description=iphone&page=0&size=20
 
 ###item name
-GET localhost:8081/search/auctions/itemName/startWith?itemName=아이폰&sortProperties=STARTING_PRICE&direction=DESC&page=0&size=20
+GET localhost:8081/search/auctions/itemName/contain?itemName=프로&sortProperties=STARTING_PRICE&direction=DESC&page=0&size=20
 

--- a/elastic-search.http
+++ b/elastic-search.http
@@ -1,14 +1,14 @@
 ###es save
-POST http://localhost:8081/search/auctionDocument/2
+POST http://localhost:8081/search/auction-document/2
 
 ###Starting Price
-GET http://localhost:8081/search/auctions/startingPrice?startingPrice=1000&size=10
+GET http://localhost:8081/search/auctions/starting-price?startingPrice=1000&size=10
 
 ###minimumBid
-GET http://localhost:8081/search/auctions/minimumBid?minimumBid=100&size=10
+GET http://localhost:8081/search/auctions/minimum-bid?minimumBid=100&size=10
 
 ###itemStatus
-GET http://localhost:8081/search/auctions/itemStatus?itemStatus=GOOD&page=1&size=20
+GET http://localhost:8081/search/auctions/item-status?itemStatus=GOOD&page=1&size=20
 
 ###category
 GET http://localhost:8081/search/auctions/category?category=BAG&page=1&size=20
@@ -23,5 +23,5 @@ GET http://localhost:8081/search/auctions/description/matches?description=애플
 GET http://localhost:8081/search/auctions/description/contains?description=iphone&page=0&size=20
 
 ###item name
-GET localhost:8081/search/auctions/itemName/contain?itemName=프로&sortProperties=STARTING_PRICE&direction=DESC&page=0&size=20
+GET localhost:8081/search/auctions/item-name/contain?itemName=프로&sortProperties=STARTING_PRICE&direction=DESC&page=0&size=20
 


### PR DESCRIPTION
change
---
1. 경매 종료 시 elastic document 삭제 하여 검색이 불가능 하도록 변경
2. Item name search 로직 변경
   1. 기존 : 해당 키워드로 시작되는 물품만 응답 (키워드가 item name 에서 시작하지 않으면 응답 안함 - **애플 아이폰 프로**에서 아이폰을 검색하면 응답 안함)
   2. 변경 : item name 에 해당 키워드가 **포함**되어 있는 모든 것을 응답 (애플 아이폰 프로에서 **아이폰**을 검색하면 응답)
3. item name search url 변경
   1. 기존 : ~/itemName/**startWith**
   2. 변경 : ~/itemName/**contain**
4. search controller url : Restful format 으로 end point 변경 (대문자 -> 소문자로 변경)

closes #121 