### PR TITLE
Feat : [feat/#124/wish-list/0] 경매 종료시 wish list 삭제

### DIFF
--- a/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionServiceTest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.example.a_uction.model.wishList.repository.WishRepository;
 import com.example.a_uction.service.search.AuctionSearchService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -78,6 +79,8 @@ class AuctionServiceTest {
 	private AuctionSearchRepository auctionSearchRepository;
 	@Mock
 	private AuctionSearchQueryRepository auctionSearchQueryRepository;
+	@Mock
+	private WishRepository wishRepository;
 
 	private static final String TEST_IMAGE_SRC = "src/test/resources/image/test.png";
 
@@ -762,6 +765,8 @@ class AuctionServiceTest {
 		assertEquals(response.getTransactionStatus(), TransactionStatus.TRANSACTION_COMPLETE);
 		assertEquals(response.getBuyerId(), user.getId());
 		assertEquals(response.getImagesSrc().get(0), "~/test/test.png");
+
+		verify(wishRepository, times(1)).deleteByWishAuctionAuctionId(anyLong());
 	}
 
 	@Test


### PR DESCRIPTION
change
---
1. 경매 종료시 wish list 에서 해당 경매 모두 삭제

To reviewer
---
해당 기능을 구현 후 변경 사항은  #124  참고 부탁 드립니다. 
금일 슬랙으로 말씀 드렸듯이 제가 실수하여 main 으로 push 하였습니다. 죄송합니다.
