### PR TITLE
[feat/#132/chat-refactor] form 입력하던 구조에서 contensts 만 입력할 수 있도록 변경

### DIFF
--- a/a_uction/src/main/java/com/example/a_uction/config/ChatInterceptor.java
+++ b/a_uction/src/main/java/com/example/a_uction/config/ChatInterceptor.java
@@ -1,15 +1,18 @@
 package com.example.a_uction.config;
 
 import com.example.a_uction.security.jwt.JwtProvider;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpHeaders;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
@@ -22,11 +25,15 @@ public class ChatInterceptor implements ChannelInterceptor {
 
 	@Value("${jwt.prefix}")
 	private String tokenPrefix;
+	private final RedisTemplate<String, Object> redisTemplate;
+
 	@Override
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
 		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
 		if (accessor.getCommand() == StompCommand.CONNECT) {
+
+			Object simpSessionId = message.getHeaders().get("simpSessionId");
 
 			String authorization = String.valueOf(
 				accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION));
@@ -37,6 +44,20 @@ public class ChatInterceptor implements ChannelInterceptor {
 
 			SecurityContextHolder.getContext()
 				.setAuthentication(provider.getAuthentication(token));
+
+			redisTemplate.opsForValue()
+				.set(Objects.requireNonNull(simpSessionId).toString(), token);
+		}
+
+		if (accessor.getCommand() == StompCommand.SEND) {
+			Object simpSessionId = message.getHeaders().get("simpSessionId");
+			String token = (String) redisTemplate.opsForValue()
+				.get(Objects.requireNonNull(simpSessionId).toString());
+
+			Authentication authentication = provider.getAuthentication(token);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+
+			accessor.setNativeHeader("principal", provider.getUserEmail(token));
 		}
 
 		return message;

--- a/a_uction/src/main/java/com/example/a_uction/controller/chat/ChatController.java
+++ b/a_uction/src/main/java/com/example/a_uction/controller/chat/ChatController.java
@@ -2,8 +2,10 @@ package com.example.a_uction.controller.chat;
 
 import com.example.a_uction.model.chat.dto.Message;
 import com.example.a_uction.service.chat.ChatMessageService;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,13 +20,13 @@ public class ChatController {
 	private final ChatMessageService chatMessageService;
 
 	@MessageMapping("/chatting")
-	public void sendMessage(@Payload Message message) {
-		chatMessageService.sendChatMessage(message);
+	public void sendMessage(@Payload Message message, @Headers Map<String, String> map) {
+		chatMessageService.sendChatMessage(message, map.get("simpSessionId"));
 	}
 
 	@MessageMapping("/bidding")
-	public void bidding(@Payload Message message) {
-		chatMessageService.bidding(message);
+	public void bidding(@Payload Message message, @Headers Map<String, String> map ) {
+		chatMessageService.bidding(message, map.get("simpSessionId"));
 	}
 
 	@GetMapping("/{chatRoomId}/get-connected-users")

--- a/a_uction/src/main/java/com/example/a_uction/service/auction/AuctionService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/auction/AuctionService.java
@@ -183,7 +183,7 @@ public class AuctionService {
 		}
 	}
 
-	public AuctionDto.Response auctionFinished(AuctionEntity auction) {
+	public void auctionFinished(AuctionEntity auction) {
 
 		Long auctionId = auction.getAuctionId();
 
@@ -227,7 +227,7 @@ public class AuctionService {
 			auction.setTransactionStatus(TransactionStatus.TRANSACTION_FAIL);
 		}
 		deleteDataAboutAuction(auctionId);
-		return AuctionDto.Response.fromEntity(auctionRepository.save(auction));
+		Response.fromEntity(auctionRepository.save(auction));
 	}
 
 	@Transactional

--- a/a_uction/src/main/java/com/example/a_uction/service/chat/ChatApplication.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/chat/ChatApplication.java
@@ -1,9 +1,14 @@
 package com.example.a_uction.service.chat;
 
+import com.example.a_uction.model.chat.constants.MessageType;
+import com.example.a_uction.model.chat.dto.Message;
+import com.example.a_uction.security.jwt.JwtProvider;
+import java.security.Principal;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
@@ -14,11 +19,16 @@ public class ChatApplication {
 
 	private final RedisTemplate<String, Integer> chatRedisTemplate;
 	private final RedisTemplate<String, Object> redisTemplate;
+	private final SimpMessageSendingOperations simpMessageSendingOperations;
+	private final JwtProvider provider;
 
 	private static final String DESTINATION_HEADER = "simpDestination";
 	private static final String SESSION_ID_HEADER = "simpSessionId";
 	private static final String TOTAL_USERS_COUNT_PACKAGE = "TotalUserCount:";
 	private static final String JOIN_TO_INFO_PACKAGE = "JoinChatting:";
+	private static final String ENTER_MESSAGE = "님이 입장하셨습니다.";
+	private static final String DESTINATION_PREFIX = "/topic/";
+	private static final String BIDDING_CHAT_ROOM_TYPE = "bid";
 
 	@EventListener(SessionSubscribeEvent.class)
 	public void onSubscription(SessionSubscribeEvent event) {
@@ -28,19 +38,26 @@ public class ChatApplication {
 				.toString()
 				.split("/")[2];
 
-		redisTemplate.opsForValue()
-			.set(JOIN_TO_INFO_PACKAGE + Objects.requireNonNull(
-				event.getMessage().getHeaders().get(SESSION_ID_HEADER)), chatRoomId);
+		String redisKey = Objects
+			.requireNonNull(event.getMessage().getHeaders().get(SESSION_ID_HEADER)).toString();
 
+		redisTemplate.opsForValue()
+			.set(JOIN_TO_INFO_PACKAGE + redisKey, chatRoomId);
 		int count =
 			chatRedisTemplate.opsForValue()
 				.get(TOTAL_USERS_COUNT_PACKAGE + chatRoomId) != null ? Objects.requireNonNull(
-				chatRedisTemplate.opsForValue().get(TOTAL_USERS_COUNT_PACKAGE + chatRoomId)) + 1 : 1;
+				chatRedisTemplate.opsForValue().get(TOTAL_USERS_COUNT_PACKAGE + chatRoomId)) + 1
+				: 1;
 
 		setData(chatRoomId, count);
+
+		if (!chatRoomId.contains(BIDDING_CHAT_ROOM_TYPE)) {
+			sendEnterMessage(redisKey, chatRoomId);
+		}
 	}
+
 	@EventListener(SessionDisconnectEvent.class)
-	public void onDisconnection (SessionDisconnectEvent disconnectEvent) {
+	public void onDisconnection(SessionDisconnectEvent disconnectEvent) {
 
 		String chatRoomId = String.valueOf(
 			redisTemplate.opsForValue()
@@ -50,15 +67,35 @@ public class ChatApplication {
 			chatRedisTemplate.opsForValue().get(TOTAL_USERS_COUNT_PACKAGE + chatRoomId)) - 1;
 
 		this.setData(chatRoomId, count);
+
+		redisTemplate.delete(disconnectEvent.getSessionId());
 	}
+
 	private void setData(String chatRoomId, int count) {
 		if (count < 1) {
-			 chatRedisTemplate.delete(TOTAL_USERS_COUNT_PACKAGE + chatRoomId);
+			chatRedisTemplate.delete(TOTAL_USERS_COUNT_PACKAGE + chatRoomId);
 		} else {
 			chatRedisTemplate.opsForValue().set(TOTAL_USERS_COUNT_PACKAGE + chatRoomId, count);
 		}
 	}
+
 	public Integer getUsers(String chatRoomId) {
 		return chatRedisTemplate.opsForValue().get(TOTAL_USERS_COUNT_PACKAGE + chatRoomId);
+	}
+
+	private void sendEnterMessage(String redisKey, String chatRoomId) {
+		String token = (String) redisTemplate.opsForValue().get(redisKey);
+
+		Principal principal = provider.getAuthentication(token);
+
+		simpMessageSendingOperations.convertAndSend(
+			DESTINATION_PREFIX + chatRoomId
+			, Message.builder()
+				.chatRoomId(chatRoomId)
+				.messageType(MessageType.ENTER)
+				.sender(principal.getName())
+				.contents(principal.getName() + ENTER_MESSAGE)
+				.build()
+		);
 	}
 }

--- a/a_uction/src/main/java/com/example/a_uction/service/chat/ChatMessageService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/chat/ChatMessageService.java
@@ -10,6 +10,7 @@ import com.example.a_uction.model.chat.constants.MessageType;
 import com.example.a_uction.model.chat.dto.Message;
 import com.example.a_uction.model.user.entity.UserEntity;
 import com.example.a_uction.model.user.repository.UserRepository;
+import com.example.a_uction.security.jwt.JwtProvider;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.Optional;
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,29 +28,42 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class ChatMessageService {
-	private static final String ENTER_MESSAGE = "님이 입장하셨습니다.";
+
 	private static final String DESTINATION_PREFIX = "/topic/";
+	private static final String JOIN_TO_INFO_PACKAGE = "JoinChatting:";
 
 	private final SimpMessageSendingOperations simpMessageSendingOperations;
 
 	private final BiddingHistoryRepository biddingHistoryRepository;
+	private final JwtProvider provider;
+	private final RedisTemplate<String, Object> redisTemplate;
 	private final UserRepository userRepository;
 	private final AuctionRepository auctionRepository;
 	private final RedissonClient redissonClient;
 	private final ChatApplication chatApplication;
 
-	public void sendChatMessage(Message message) {
+	public void sendChatMessage(Message message, String sessionId) {
 
-		if (message.getMessageType().equals(MessageType.ENTER)) {
-			message.setContents(message.getSender() + ENTER_MESSAGE);
-		}
+		setMessage(message, sessionId);
 
 		simpMessageSendingOperations
 			.convertAndSend(DESTINATION_PREFIX + message.getChatRoomId(), message);
 	}
+	private void setMessage(Message message, String sessionId) {
+		String token = (String)redisTemplate.opsForValue().get(sessionId);
+		message.setSender(provider.getUserEmail(token));
+		String chatRoomId = (String) redisTemplate.opsForValue().get(JOIN_TO_INFO_PACKAGE + sessionId);
+		if (Objects.requireNonNull(chatRoomId).contains("chat")) {
+			message.setMessageType(MessageType.SEND);
+		} else {
+			message.setMessageType(MessageType.BIDDING);
+		}
+		message.setChatRoomId(chatRoomId);
+	}
 
 	@Transactional
-	public void bidding(Message message) {
+	public void bidding(Message message, String sessionId) {
+		setMessage(message, sessionId);
 		Long auctionId = Long.parseLong(message.getChatRoomId().replace("bid", ""));
 		String lockKey = "auction_lock:" + auctionId;
 		RLock lock = redissonClient.getLock(lockKey);
@@ -60,68 +75,76 @@ public class ChatMessageService {
 			createBiddingHistory(message.getSender(), auctionId, bidPrice);
 
 			simpMessageSendingOperations
-					.convertAndSend(DESTINATION_PREFIX + message.getChatRoomId(), message);
+				.convertAndSend(DESTINATION_PREFIX + message.getChatRoomId(), message);
 		} finally {
 			lock.unlock();
 		}
 	}
 
-
 	public Integer getUsers(String chatRoomId) {
 		return chatApplication.getUsers(chatRoomId);
 	}
 
-	public int getMaxBiddablePrice(Long auctionId){
-		Optional<BiddingHistoryEntity> optionalBiddingHistory = biddingHistoryRepository.findFirstByAuctionIdOrderByCreatedDateDesc(auctionId);
+	public int getMaxBiddablePrice(Long auctionId) {
+		Optional<BiddingHistoryEntity> optionalBiddingHistory = biddingHistoryRepository.findFirstByAuctionIdOrderByCreatedDateDesc(
+			auctionId);
 		AuctionEntity auction = auctionRepository.findById(auctionId)
-				.orElseThrow(() -> new AuctionException(ErrorCode.AUCTION_NOT_FOUND));
+			.orElseThrow(() -> new AuctionException(ErrorCode.AUCTION_NOT_FOUND));
 
 		return optionalBiddingHistory
-				.map(biddingHistoryEntity -> biddingHistoryEntity.getPrice() + auction.getMinimumBid())
-				.orElseGet(auction::getStartingPrice);
+			.map(biddingHistoryEntity -> biddingHistoryEntity.getPrice() + auction.getMinimumBid())
+			.orElseGet(auction::getStartingPrice);
 	}
 
-	private UserEntity getUser(String userEmail){
+	private UserEntity getUser(String userEmail) {
 		return userRepository.getByUserEmail(userEmail);
 	}
 
-	private boolean biddingPossible(Long auctionId, Long bidderId, int price){
+	private boolean biddingPossible(Long auctionId, Long bidderId, int price) {
 		AuctionEntity auction = auctionRepository.findById(auctionId)
-				.orElseThrow(() -> new AuctionException(ErrorCode.AUCTION_NOT_FOUND));
-		Optional<BiddingHistoryEntity> optionalBiddingHistory = biddingHistoryRepository.findFirstByAuctionIdOrderByCreatedDateDesc(auctionId);
+			.orElseThrow(() -> new AuctionException(ErrorCode.AUCTION_NOT_FOUND));
+		Optional<BiddingHistoryEntity> optionalBiddingHistory = biddingHistoryRepository.findFirstByAuctionIdOrderByCreatedDateDesc(
+			auctionId);
 		UserEntity user = userRepository.findById(bidderId)
-				.orElseThrow(() -> new AuctionException(ErrorCode.USER_NOT_FOUND));
+			.orElseThrow(() -> new AuctionException(ErrorCode.USER_NOT_FOUND));
+		//경매 종료됌
+		if (auction.getEndDateTime().isBefore(LocalDateTime.now())) {
+
+			throw new AuctionException(ErrorCode.AUCTION_FINISHED);
+		}
 		//경매 등록자 본인이 입찰 시도 - 테스트시 주석처리
-		if (Objects.equals(auction.getUser().getId(), bidderId))
+		if (Objects.equals(auction.getUser().getId(), bidderId)) {
 			throw new AuctionException(ErrorCode.REGISTER_CANNOT_BID);
-		if (optionalBiddingHistory.isPresent()){
-			if (Objects.equals(optionalBiddingHistory.get().getBidderEmail(), user.getUserEmail())){
+		}
+		if (optionalBiddingHistory.isPresent()) {
+			if (Objects.equals(optionalBiddingHistory.get().getBidderEmail(),
+				user.getUserEmail())) {
 				throw new AuctionException(ErrorCode.LAST_BIDDER_SAME);
 			}
 		}
 		//경매 시작 안함
-		if (auction.getStartDateTime().isAfter(LocalDateTime.now()))
+		if (auction.getStartDateTime().isAfter(LocalDateTime.now())) {
 			throw new AuctionException(ErrorCode.AUCTION_NOT_STARTS);
-		//경매 종료됌
-		if (auction.getEndDateTime().isBefore(LocalDateTime.now()))
-			throw new AuctionException(ErrorCode.AUCTION_FINISHED);
+		}
 		//입찰 시도 금액이 현재 입찰 금액보다 작거나, 경매 시작 금액보다 작음
-		if (price < getMaxBiddablePrice(auctionId))
+		if (price < getMaxBiddablePrice(auctionId)) {
 			throw new AuctionException(ErrorCode.NOT_BIDDABLE_PRICE);
+		}
 		// 입찰 금액보다 소유한 예치금이 작음
-		if (price > user.getBalance())
+		if (price > user.getBalance()) {
 			throw new AuctionException(ErrorCode.NOT_ENOUGH_USER_BALANCE);
+		}
 
 		return true;
 	}
 
-	private void createBiddingHistory(String userEmail, Long auctionId, int price){
+	private void createBiddingHistory(String userEmail, Long auctionId, int price) {
 		UserEntity user = getUser(userEmail);
 		if (!biddingPossible(auctionId, user.getId(), price)) {
-			throw  new AuctionException(ErrorCode.UNABLE_CREATE_BID);
+			throw new AuctionException(ErrorCode.UNABLE_CREATE_BID);
 		}
 		biddingHistoryRepository.save(
-				BiddingHistoryEntity.builder()
+			BiddingHistoryEntity.builder()
 				.bidderEmail(user.getUserEmail())
 				.auctionId(auctionId)
 				.price(price)

--- a/a_uction/src/main/java/com/example/a_uction/service/user/UserBalanceService.java
+++ b/a_uction/src/main/java/com/example/a_uction/service/user/UserBalanceService.java
@@ -5,6 +5,7 @@ import static com.example.a_uction.exception.constants.ErrorCode.USER_NOT_FOUND;
 
 import com.example.a_uction.exception.AuctionException;
 import com.example.a_uction.model.user.dto.Balance;
+import com.example.a_uction.model.user.dto.Balance.Request;
 import com.example.a_uction.model.user.entity.BalanceHistoryEntity;
 import com.example.a_uction.model.user.entity.UserEntity;
 import com.example.a_uction.model.user.repository.BalanceHistoryRepository;
@@ -27,16 +28,17 @@ public class UserBalanceService {
 
 	}
 
-	public Balance.Response withdraw(String userEmail, Balance.Request withdrawBalance) {
+	public void withdraw(String userEmail, Request withdrawBalance) {
 
 		BalanceHistoryEntity balanceHistory = this.getByUserEmail(userEmail);
 		withdrawBalance.setMoney(-withdrawBalance.getMoney());
-		return this.change(balanceHistory, withdrawBalance);
+		this.change(balanceHistory, withdrawBalance);
 	}
 
 	@Transactional
 	public Balance.Response change(BalanceHistoryEntity balanceHistory,
 		Balance.Request changeBalance) {
+
 
 		Integer currentMoney = balanceHistory.getCurrentMoney() + changeBalance.getMoney();
 		if (currentMoney < 0) {

--- a/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionServiceTest.java
+++ b/a_uction/src/test/java/com/example/a_uction/service/auction/AuctionServiceTest.java
@@ -64,8 +64,12 @@ class AuctionServiceTest {
 
 	@Mock
 	private BiddingHistoryRepository biddingHistoryRepository;
+
 	@Mock
 	private AuctionTransactionHistoryRepository auctionTransactionHistoryRepository;
+
+	@Mock
+	private WishRepository wishRepository;
 
 	@Mock
 	private AuctionFileService auctionFileService;
@@ -80,8 +84,6 @@ class AuctionServiceTest {
 	private AuctionSearchRepository auctionSearchRepository;
 	@Mock
 	private AuctionSearchQueryRepository auctionSearchQueryRepository;
-	@Mock
-	private WishRepository wishRepository;
 
 	private static final String TEST_IMAGE_SRC = "src/test/resources/image/test.png";
 


### PR DESCRIPTION
Changes
---

발행할 때
발행 destination url 만 있다면
chat-message, bidding-message 둘다 contents 만 입력해도 다른 정보가 담기도록 변경

Background
---

socket 연결을 자동으로 끊어주는 것은 server 에서 할 수 없음
redis 에 sessionId - JWT 를 저장함  


closes #132 #133 